### PR TITLE
Binary Calls and Manual Decoding

### DIFF
--- a/chainweb-data.cabal
+++ b/chainweb-data.cabal
@@ -54,7 +54,9 @@ executable chainweb-data
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   build-depends:
     , bytestring            ^>=0.10
+    , cereal                ^>=0.5
     , chainweb-data
+    , errors                ^>=2.3
     , http-client           ^>=0.6
     , http-client-tls       ^>=0.3
     , microlens             ^>=0.4

--- a/exec/Chainweb/Backfill.hs
+++ b/exec/Chainweb/Backfill.hs
@@ -55,7 +55,11 @@ work e@(Env _ c _ _) cn p@(Parent h) cid = inBlocks >>= \case
       Just hd -> do
         runBeamSqlite c . runInsert . insert (headers database) $ insertValues [hd]
         count <- atomically $ modifyTVar' cn (+ 1) >> readTVar cn
-        T.putStrLn $ "[OKAY] Queued new parent: " <> unDbHash h <> " " <> T.pack (show count)
+        liftIO $ printf "[OKAY] Chain %d: %d: %s: %d\n"
+          (_header_chainId hd)
+          (_header_height hd)
+          (unDbHash $ _header_hash hd)
+          count
         work e cn (Parent $ _header_parent hd) cid
   where
     inBlocks = runBeamSqlite c . runSelectReturningOne $ lookup_ (blocks database) (BlockId h)

--- a/exec/Chainweb/New.hs
+++ b/exec/Chainweb/New.hs
@@ -31,7 +31,7 @@ ingest (Env m c u _) = withEvents (req u) m
       $ insertValues [asHeader bh]
 
     h :: PowHeader -> IO ()
-    h (PowHeader bh _) = printf "Chain %d: %d: %s\n"
+    h (PowHeader bh _) = printf "[OKAY] Chain %d: %d: %s\n"
       (unChainId $ _blockHeader_chainId bh)
       (_blockHeader_height bh)
       (hashB64U $ _blockHeader_hash bh)

--- a/exec/Chainweb/Types.hs
+++ b/exec/Chainweb/Types.hs
@@ -5,10 +5,11 @@
 module Chainweb.Types
   ( PowHeader(..)
   , asHeader
+  , asPow
   ) where
 
 import           BasePrelude
-import           Chainweb.Api.BlockHeader (BlockHeader(..))
+import           Chainweb.Api.BlockHeader (BlockHeader(..), powHash)
 import           Chainweb.Api.BytesLE
 import           Chainweb.Api.ChainId (ChainId(..))
 import           Chainweb.Api.Hash
@@ -23,8 +24,6 @@ import           Network.Wai.EventSource.Streaming
 
 ---
 
--- TODO No this needs to live in `chainweb-api` as `RichHeader`.
-
 data PowHeader = PowHeader
   { _hwp_header :: BlockHeader
   , _hwp_powHash :: T.Text }
@@ -36,10 +35,8 @@ instance FromEvent PowHeader where
       <$> (hu ^? key "header"  . _JSON)
       <*> (hu ^? key "powHash" . _JSON)
 
-instance FromJSON PowHeader where
-    parseJSON = withObject "PowHeader" $ \v -> PowHeader
-        <$> v .: "header"
-        <*> v .: "powHash"
+asPow :: BlockHeader -> PowHeader
+asPow bh = PowHeader bh (hashB64U $ powHash bh)
 
 asHeader :: PowHeader -> Header
 asHeader (PowHeader bh ph) = Header

--- a/exec/Chainweb/Update.hs
+++ b/exec/Chainweb/Update.hs
@@ -70,7 +70,11 @@ writes' cn c h (Quad _ b m ts) = runBeamSqlite c $ do
       runInsert . insert (blocks database) $ insertValues [b]
       runInsert . insert (transactions database) $ insertValues ts
       cnt <- liftIO . atomically $ modifyTVar' cn (+ 1) >> readTVar cn
-      liftIO . T.putStrLn $ "[OKAY] " <> unDbHash (_header_hash h) <> " " <> T.pack (show cnt)
+      liftIO $ printf "[OKAY] Chain %d: %d: %s: %d\n"
+        (_block_chainId b)
+        (_block_height b)
+        (unDbHash $ _block_hash b)
+        cnt
 
 lookups :: Env -> Header -> IO (Maybe Quad)
 lookups e h = runMaybeT $ do

--- a/exec/Chainweb/Update.hs
+++ b/exec/Chainweb/Update.hs
@@ -19,7 +19,6 @@ import           ChainwebDb.Types.DbHash
 import           ChainwebDb.Types.Header
 import           ChainwebDb.Types.Miner
 import           ChainwebDb.Types.Transaction
-import           Control.Concurrent.STM.TVar
 import           Control.Monad.Trans.Maybe
 import           Control.Scheduler (Comp(..), traverseConcurrently_)
 import           Data.Aeson (decode')
@@ -38,19 +37,18 @@ data Quad = Quad !BlockPayload !Block !Miner ![Transaction]
 updates :: Env -> IO ()
 updates e@(Env _ c _ _) = do
   hs <- runBeamSqlite c . runSelectReturningList $ select prd
-  cn <- newTVarIO 0
-  traverseConcurrently_ Par' (\h -> lookups e h >>= writes cn c h) hs
+  traverseConcurrently_ (ParN 8) (\h -> lookups e h >>= writes c h) hs
   where
     prd = all_ $ headers database
 
 -- | Write a Block and its Transactions to the database. Also writes the Miner
 -- if it hasn't already been via some other block.
-writes :: TVar Int -> Connection -> Header -> Maybe Quad -> IO ()
-writes cn c h (Just q) = writes' cn c h q
-writes _ _ h _ = T.putStrLn $ "[FAIL] Payload fetch for Block: " <> unDbHash (_header_hash h)
+writes :: Connection -> Header -> Maybe Quad -> IO ()
+writes c h (Just q) = writes' c h q
+writes _ h _ = T.putStrLn $ "[FAIL] Payload fetch for Block: " <> unDbHash (_header_hash h)
 
-writes' :: TVar Int -> Connection -> Header -> Quad -> IO ()
-writes' cn c h (Quad _ b m ts) = runBeamSqlite c $ do
+writes' :: Connection -> Header -> Quad -> IO ()
+writes' c h (Quad _ b m ts) = runBeamSqlite c $ do
   -- Remove the Header from the work queue --
   runDelete
     $ delete (headers database)
@@ -69,12 +67,10 @@ writes' cn c h (Quad _ b m ts) = runBeamSqlite c $ do
     Nothing -> do
       runInsert . insert (blocks database) $ insertValues [b]
       runInsert . insert (transactions database) $ insertValues ts
-      cnt <- liftIO . atomically $ modifyTVar' cn (+ 1) >> readTVar cn
-      liftIO $ printf "[OKAY] Chain %d: %d: %s: %d\n"
+      liftIO $ printf "[OKAY] Chain %d: %d: %s\n"
         (_block_chainId b)
         (_block_height b)
         (unDbHash $ _block_hash b)
-        cnt
 
 lookups :: Env -> Header -> IO (Maybe Quad)
 lookups e h = runMaybeT $ do

--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -23,6 +23,7 @@ main = do
   Args c (DBPath d) u v <- execParser opts
   bracket (open d) close $ \conn -> do
     initializeTables conn
+    putStrLn "DB Tables Initialized"
     m <- newManager tlsManagerSettings
     let !env = Env m conn u v
     case c of

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,4 +5,4 @@ ghc-options: {"$locals": -ddump-to-file -ddump-hi}
 extra-deps:
   - streaming-events-1.0.1
   - github: kadena-io/chainweb-api
-    commit: 5ff81646fca933024653cae3101f81c03c7f19d8
+    commit: 2f54cae4c029bcdb3a7f09b5dd766cc365e14c34

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,4 +5,4 @@ ghc-options: {"$locals": -ddump-to-file -ddump-hi}
 extra-deps:
   - streaming-events-1.0.1
   - github: kadena-io/chainweb-api
-    commit: 0ebb4dfa66a35868af3f4c9a8eed992af0aedec3
+    commit: 5ff81646fca933024653cae3101f81c03c7f19d8

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.23
+resolver: lts-14.25
 
 ghc-options: {"$locals": -ddump-to-file -ddump-hi}
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,8 @@
-resolver: lts-14.22
+resolver: lts-14.23
 
 ghc-options: {"$locals": -ddump-to-file -ddump-hi}
 
 extra-deps:
   - streaming-events-1.0.1
   - github: kadena-io/chainweb-api
-    commit: 07a515e9b5401b73ff59af55b369590273decce7
+    commit: 0ebb4dfa66a35868af3f4c9a8eed992af0aedec3


### PR DESCRIPTION
This PR uses an updated `chainweb-api` to avoid the JSON endpoints for calling `BlockHeader`s and call the more efficient binary variants.