### PR TITLE
Fix Backfill

### DIFF
--- a/chainweb-data.cabal
+++ b/chainweb-data.cabal
@@ -53,7 +53,7 @@ executable chainweb-data
   hs-source-dirs: exec
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-    , async ^>= 2.2
+    , async                 ^>=2.2
     , bytestring            ^>=0.10
     , cereal                ^>=0.5
     , chainweb-data
@@ -63,6 +63,7 @@ executable chainweb-data
     , microlens             ^>=0.4
     , microlens-aeson       ^>=2.3
     , optparse-applicative  ^>=0.14
+    , resource-pool         ^>=0.2
     , scheduler             ^>=1.4
     , stm
     , streaming             ^>=0.2

--- a/chainweb-data.cabal
+++ b/chainweb-data.cabal
@@ -53,6 +53,7 @@ executable chainweb-data
   hs-source-dirs: exec
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   build-depends:
+    , async ^>= 2.2
     , bytestring            ^>=0.10
     , cereal                ^>=0.5
     , chainweb-data
@@ -63,8 +64,10 @@ executable chainweb-data
     , microlens-aeson       ^>=2.3
     , optparse-applicative  ^>=0.14
     , scheduler             ^>=1.4
+    , stm
     , streaming             ^>=0.2
     , streaming-events      ^>=1.0.1
+    , strict-tuple          ^>=0.1
     , transformers          ^>=0.5
 
   other-modules:

--- a/chainweb-data.cabal
+++ b/chainweb-data.cabal
@@ -65,7 +65,7 @@ executable chainweb-data
     , optparse-applicative  ^>=0.14
     , resource-pool         ^>=0.2
     , scheduler             ^>=1.4
-    , stm
+    , stm                   ^>=2.5
     , streaming             ^>=0.2
     , streaming-events      ^>=1.0.1
     , strict-tuple          ^>=0.1

--- a/exec/Chainweb/Env.hs
+++ b/exec/Chainweb/Env.hs
@@ -34,7 +34,7 @@ getConnection (PGString s) = connectPostgreSQL s
 
 -- | A bracket for `Connection` interaction.
 withConnection :: Connect -> (Connection -> IO a) -> IO a
-withConnection c f = bracket (getConnection c) close f
+withConnection c = bracket (getConnection c) close
 
 -- | Create a `Pool` based on `Connect` settings designated on the command line.
 getPool :: Connect -> IO (Pool Connection)
@@ -44,7 +44,7 @@ getPool c = do
 
 -- | A bracket for `Pool` interaction.
 withPool :: Connect -> (Pool Connection -> IO a) -> IO a
-withPool c f = bracket (getPool c) destroyAllResources f
+withPool c = bracket (getPool c) destroyAllResources
 
 newtype Url = Url String
   deriving newtype (IsString)

--- a/exec/Chainweb/Update.hs
+++ b/exec/Chainweb/Update.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -38,11 +39,12 @@ import           Network.HTTP.Client hiding (Proxy)
 data Quad = Quad !BlockPayload !Block !Miner ![Transaction]
 
 updates :: Env -> IO ()
-updates e@(Env _ c _ _) = withPool c $ \pool -> do
+updates e@(Env _ c _ _) = forever $ withPool c $ \pool -> do
   hs <- P.withResource pool $ \conn -> runBeamPostgres conn . runSelectReturningList
     $ select
     $ all_ (headers database)
   traverseConcurrently_ Par' (\h -> lookups e h >>= writes pool h) hs
+  threadDelay 5_000_000
 
 -- | Write a Block and its Transactions to the database. Also writes the Miner
 -- if it hasn't already been via some other block.

--- a/exec/Chainweb/Update.hs
+++ b/exec/Chainweb/Update.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -39,12 +38,11 @@ import           Network.HTTP.Client hiding (Proxy)
 data Quad = Quad !BlockPayload !Block !Miner ![Transaction]
 
 updates :: Env -> IO ()
-updates e@(Env _ c _ _) = forever $ withPool c $ \pool -> do
+updates e@(Env _ c _ _) = withPool c $ \pool -> do
   hs <- P.withResource pool $ \conn -> runBeamPostgres conn . runSelectReturningList
     $ select
     $ all_ (headers database)
   traverseConcurrently_ Par' (\h -> lookups e h >>= writes pool h) hs
-  threadDelay 5_000_000
 
 -- | Write a Block and its Transactions to the database. Also writes the Miner
 -- if it hasn't already been via some other block.

--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE NumericUnderscores #-}
 
 module Main where
 
@@ -24,8 +25,8 @@ main = do
     let !env = Env m pgc u v
     case c of
       Listen -> ingest env
-      Worker -> updates env
       Backfill -> backfill env
+      Worker -> forever (updates env >> threadDelay 5_000_000)
   where
     opts = info (envP <**> helper)
       (fullDesc <> header "chainweb-data - Processing and analysis of Chainweb data")

--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -8,24 +8,20 @@ import Chainweb.Database (initializeTables)
 import Chainweb.Env
 import Chainweb.New (ingest)
 import Chainweb.Update (updates)
-import Control.Exception (bracket)
-import Database.Beam.Postgres (Connection, close, connect, connectPostgreSQL)
-import Network.HTTP.Client
+import Network.HTTP.Client hiding (withConnection)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Options.Applicative
 
 ---
 
--- Note: The `bracket` here catches exceptions (including Ctrl+C) and safely
--- closes the connection to the database.
 main :: IO ()
 main = do
   Args c pgc u v <- execParser opts
-  bracket (f pgc) close $ \conn -> do
+  withConnection pgc $ \conn -> do
     initializeTables conn
     putStrLn "DB Tables Initialized"
     m <- newManager tlsManagerSettings
-    let !env = Env m conn u v
+    let !env = Env m pgc u v
     case c of
       Listen -> ingest env
       Worker -> updates env
@@ -33,7 +29,3 @@ main = do
   where
     opts = info (envP <**> helper)
       (fullDesc <> header "chainweb-data - Processing and analysis of Chainweb data")
-
-    f :: Connect -> IO Connection
-    f (PGInfo ci) = connect ci
-    f (PGString s) = connectPostgreSQL s

--- a/lib/ChainwebDb/Types/Header.hs
+++ b/lib/ChainwebDb/Types/Header.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
@@ -28,8 +30,11 @@ data HeaderT f = Header
   deriving stock (Generic)
   deriving anyclass (Beamable)
 
+
 type Header = HeaderT Identity
 type HeaderId = PrimaryKey HeaderT Identity
+
+deriving instance Show Header
 
 instance Table HeaderT where
   data PrimaryKey HeaderT f = HeaderId (C f DbHash)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,13 +1,13 @@
-resolver: lts-14.25
+resolver: lts-14.27
 
 ghc-options: {"$locals": -ddump-to-file -ddump-hi}
 
 extra-deps:
   - streaming-events-1.0.1
   - github: kadena-io/chainweb-api
-    commit: 2f54cae4c029bcdb3a7f09b5dd766cc365e14c34
+    commit: 0792df840e49821f60a8e6e5a1cdc6c5862137a1
   - github: tathougies/beam
-    commit: 2b704ee1fe55ff3a6851697040123a86540f485e
+    commit: 2fa99310557e49b37a59e349032ff7236085b6f8
     subdirs:
       - beam-core
       - beam-migrate

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ ghc-options: {"$locals": -ddump-to-file -ddump-hi}
 
 extra-deps:
   - streaming-events-1.0.1
+  - strict-tuple-0.1.3
   - github: kadena-io/chainweb-api
     commit: 0792df840e49821f60a8e6e5a1cdc6c5862137a1
   - github: tathougies/beam


### PR DESCRIPTION
This PR fixes `backfill` which was broken due to Postgres insert transactions interacting poorly with Haskell concurrency.

It also makes sure that the chains are backfilled (relatively) evenly. Previously the recursive nature of the code would fly down one chain and never look back.