### PR TITLE
Hex Hashes

### DIFF
--- a/chainweb-data.cabal
+++ b/chainweb-data.cabal
@@ -52,7 +52,8 @@ executable chainweb-data
   hs-source-dirs: exec
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-    , async                 ^>=2.2
+    , base16-bytestring     ^>=0.1
+    , base64-bytestring     ^>=1.0
     , bytestring            ^>=0.10
     , cereal                ^>=0.5
     , chainweb-data
@@ -64,11 +65,9 @@ executable chainweb-data
     , optparse-applicative  ^>=0.14
     , resource-pool         ^>=0.2
     , scheduler             ^>=1.4
-    , stm                   ^>=2.5
     , streaming             ^>=0.2
     , streaming-events      ^>=1.0.1
     , strict-tuple          ^>=0.1
-    , transformers          ^>=0.5
     , witherable-class      ^>=0
 
   other-modules:

--- a/exec/Chainweb/Types.hs
+++ b/exec/Chainweb/Types.hs
@@ -21,8 +21,11 @@ import           Chainweb.Api.MinerData
 import           ChainwebDb.Types.Block
 import           ChainwebDb.Types.DbHash (DbHash(..))
 import           Data.Aeson
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import           Lens.Micro ((^?))
 import           Lens.Micro.Aeson (key, _JSON)
@@ -42,7 +45,7 @@ instance FromEvent PowHeader where
       <*> (hu ^? key "powHash" . _JSON)
 
 asPow :: BlockHeader -> PowHeader
-asPow bh = PowHeader bh (hashB64U $ powHash bh)
+asPow bh = PowHeader bh (T.decodeUtf8 . B16.encode . B.reverse . unHash $ powHash bh)
 
 asBlock :: PowHeader -> MinerData -> Block
 asBlock (PowHeader bh ph) m = Block

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,7 @@ extra-deps:
   - strict-tuple-0.1.3
   - witherable-class-0
   - github: kadena-io/chainweb-api
-    commit: 5980773c07966449935440dad4c8877b659ea3d6
+    commit: e90509233e7073e99871c94b19c88e98ed18cd78
   - github: tathougies/beam
     commit: 2fa99310557e49b37a59e349032ff7236085b6f8
     subdirs:


### PR DESCRIPTION
This PR ensures that all commands fetch `BlockHeader`s uniformly (as binary), such that they hash to the expected POW hashes.
```
 chainid | height |                             powhash                              
---------+--------+------------------------------------------------------------------
       0 | 362727 | 00000000000076d1a9b9eea7ec7d8e4d4ab5262050c821c4870df5212bf5d84d
       1 | 362727 | 0000000000000e9cece569215d79865bc55378e2ff745f890dd1a0639ba1a0e9
       2 | 362727 | 000000000000a5a8fd17b2de523b1952cf30d403d6a7cc36ec49625e97414a65
       3 | 362727 | 0000000000015d2717b99579dd3b9fa82a44321c135e0975af4d75318ac77d6e
       0 | 362728 | 00000000000055d15430c4f4c6c98c2b7bf0dc5d0d869ab84753e591bf520f8e
       1 | 362728 | 0000000000011cc2a547bda1290a773dfd3c8e4de00e363ef633384632ba2522
       2 | 362728 | 0000000000014400ea78c02c899217a08bc53cdcc328207585a7f5eb6ccd4339
       3 | 362728 | 0000000000004ffef9bb230545df27603a19a90f603ab28c6f94fc2253aa1d86
       0 | 362729 | 00000000000161d343ca3c14b4116736ad75385132abdc8c7b85583b8ef53f26
       1 | 362729 | 0000000000009ffeb67e40e7d3d1ad9e962c159b89e0fc5d05b1d118facde2f7
       2 | 362729 | 000000000000ba52f0dc996dd016c00604f3b272a0cf8cab6eeba7d85c2ed471
       3 | 362729 | 0000000000014e81aa744810f19d7fd3906455e0237a430fd3c0cbbd1e2b34b6
       0 | 362730 | 000000000000a209c5702b419549961d9f1c43453b6a89d2172a9756e2784b4c
```

Previously, some commands were calling Chainweb via the "convenient" / "nice" JSON content types, which do **not** appear to be bit-equivalent with the binary encodings. 