### PR TITLE
Add tx outputs to the transactions table

### DIFF
--- a/exec/Chainweb/Database.hs
+++ b/exec/Chainweb/Database.hs
@@ -62,6 +62,14 @@ migratableDb = defaultMigratableDbSettings `withDbModification` dbModification
     , _tx_step = "step"
     , _tx_data = "data"
     , _tx_proof = "proof"
+
+    , _tx_gas = "gas"
+    , _tx_badResult = "badresult"
+    , _tx_goodResult = "goodresult"
+    , _tx_logs = "logs"
+    , _tx_metadata = "metadata"
+    , _tx_continuation = "continuation"
+    , _tx_txid = "txid"
     }
   , minerkeys = modifyCheckedTable id checkedTableModification
     { _minerKey_block = BlockId "block"

--- a/exec/Chainweb/Listen.hs
+++ b/exec/Chainweb/Listen.hs
@@ -30,7 +30,7 @@ listen e@(Env mgr c u _) = withPool c $ \pool ->
     f :: P.Pool Connection -> PowHeader -> IO ()
     f pool ph@(PowHeader h _) = do
       let !pair = T2 (_blockHeader_chainId h) (hash $ _blockHeader_payloadHash h)
-      payload e pair >>= \case
+      payloadWithOutputs e pair >>= \case
         Nothing -> printf "[FAIL] Couldn't fetch parent for: %s\n"
           (hashB64U $ _blockHeader_hash h)
         Just pl -> do

--- a/exec/Chainweb/Lookups.hs
+++ b/exec/Chainweb/Lookups.hs
@@ -7,7 +7,6 @@ module Chainweb.Lookups
   , High(..)
     -- * Endpoints
   , headersBetween
-  , payload
   , payloadWithOutputs
     -- * Transformations
   , txs
@@ -17,7 +16,6 @@ module Chainweb.Lookups
 
 import           BasePrelude
 import           Chainweb.Api.BlockHeader
-import           Chainweb.Api.BlockPayload
 import           Chainweb.Api.BlockPayloadWithOutputs
 import           Chainweb.Api.ChainId (ChainId(..))
 import           Chainweb.Api.ChainwebMeta
@@ -68,17 +66,6 @@ headersBetween (Env m _ (Url u) (ChainwebVersion v)) (cid, Low low, High up) = d
 
     f :: T.Text -> Maybe BlockHeader
     f = hush . (B64.decode . T.encodeUtf8 >=> runGet decodeBlockHeader)
-
-payload :: Env -> T2 ChainId DbHash -> IO (Maybe BlockPayload)
-payload (Env m _ (Url u) (ChainwebVersion v)) (T2 cid0 hsh0) = do
-  req <- parseRequest url
-  res <- httpLbs req m
-  pure . decode' $ responseBody res
-  where
-    url = "https://" <> u <> T.unpack query
-    query = "/chainweb/0.0/" <> v <> "/chain/" <> cid <> "/payload/" <> hsh
-    cid = T.pack $ show cid0
-    hsh = unDbHash hsh0
 
 payloadWithOutputs :: Env -> T2 ChainId DbHash -> IO (Maybe BlockPayloadWithOutputs)
 payloadWithOutputs (Env m _ (Url u) (ChainwebVersion v)) (T2 cid0 hsh0) = do

--- a/exec/Chainweb/Worker.hs
+++ b/exec/Chainweb/Worker.hs
@@ -53,7 +53,7 @@ writes pool b ks ts = P.withResource pool $ \c -> runBeamPostgres c $ do
 writeBlock :: Env -> P.Pool Connection -> IORef Int -> BlockHeader -> IO ()
 writeBlock e pool count bh = do
   let !pair = T2 (_blockHeader_chainId bh) (hash $ _blockHeader_payloadHash bh)
-  payload e pair >>= \case
+  payloadWithOutputs e pair >>= \case
     Nothing -> printf "[FAIL] Couldn't fetch parent for: %s\n"
       (hashB64U $ _blockHeader_hash bh)
     Just pl -> do

--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -15,10 +15,6 @@ import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Options.Applicative
 
 ---
-import Chainweb.Lookups
-import Data.Tuple.Strict
-import Chainweb.Api.ChainId
-import ChainwebDb.Types.DbHash
 
 main :: IO ()
 main = do

--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -15,6 +15,10 @@ import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Options.Applicative
 
 ---
+import Chainweb.Lookups
+import Data.Tuple.Strict
+import Chainweb.Api.ChainId
+import ChainwebDb.Types.DbHash
 
 main :: IO ()
 main = do

--- a/lib/ChainwebDb/Types/Transaction.hs
+++ b/lib/ChainwebDb/Types/Transaction.hs
@@ -24,6 +24,7 @@ import Database.Beam.Migrate.Generics (HasDefaultSqlDataType(..))
 import Database.Beam.Postgres (PgJSONB, Postgres)
 ------------------------------------------------------------------------------
 import ChainwebDb.Types.Block
+import ChainwebDb.Types.DbHash
 ------------------------------------------------------------------------------
 
 
@@ -43,7 +44,16 @@ data TransactionT f = Transaction
   , _tx_rollback :: C f (Maybe Bool)
   , _tx_step :: C f (Maybe Int)
   , _tx_data :: C f (Maybe (PgJSONB Value))
-  , _tx_proof :: C f (Maybe Text) }
+  , _tx_proof :: C f (Maybe Text)
+
+  , _tx_gas :: C f Int
+  , _tx_badResult :: C f (Maybe (PgJSONB Value))
+  , _tx_goodResult :: C f (Maybe (PgJSONB Value))
+  , _tx_logs :: C f (Maybe Text)
+  , _tx_metadata :: C f (Maybe (PgJSONB Value))
+  , _tx_continuation :: C f (Maybe (PgJSONB Value))
+  , _tx_txid :: C f (Maybe Int)
+  }
   deriving stock (Generic)
   deriving anyclass (Beamable)
 
@@ -63,6 +73,13 @@ Transaction
   (LensFor tx_step)
   (LensFor tx_data)
   (LensFor tx_proof)
+  (LensFor tx_gas)
+  (LensFor tx_badResult)
+  (LensFor tx_goodResult)
+  (LensFor tx_logs)
+  (LensFor tx_metadat)
+  (LensFor tx_continuation)
+  (LensFor tx_txid)
   = tableLenses
 
 type Transaction = TransactionT Identity

--- a/lib/ChainwebDb/Types/Transaction.hs
+++ b/lib/ChainwebDb/Types/Transaction.hs
@@ -24,7 +24,6 @@ import Database.Beam.Migrate.Generics (HasDefaultSqlDataType(..))
 import Database.Beam.Postgres (PgJSONB, Postgres)
 ------------------------------------------------------------------------------
 import ChainwebDb.Types.Block
-import ChainwebDb.Types.DbHash
 ------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Previously we were only fetching `Payload`s. This PR fetches the entire `PayloadWithOutputs` structure.