### PR TITLE
Measuring `backfill` Progress

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,11 +1,24 @@
 # Changelog
 
+## Unreleased
+
+#### Changed
+
+- `backfill` will not start unless there is at least one block in the DB for
+  each chain.
+- `backfill` shows a much more accurate progress report.
+
+#### Fixed
+
+- `backfill` should no longer fail to fetch payloads when the queried node is
+  under strain.
+
 ## 1.1.0 (2020-03-05)
 
 #### Changed
 
-The `transactions` table now stores the entire `PayloadWithOutputs` structure,
-not just the smaller `Payload`.
+- The `transactions` table now stores the entire `PayloadWithOutputs` structure,
+  not just the smaller `Payload`.
 
 ## 1.0.0 (2020-03-03)
 

--- a/chainweb-data.cabal
+++ b/chainweb-data.cabal
@@ -58,6 +58,7 @@ executable chainweb-data
   hs-source-dirs: exec
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   build-depends:
+    , async                 ^>=2.2
     , base16-bytestring
     , base64-bytestring     ^>=1.0
     , bytestring

--- a/exec/Chainweb/Worker.hs
+++ b/exec/Chainweb/Worker.hs
@@ -69,11 +69,8 @@ writeBlock e pool count bh = do
           !b = asBlock (asPow bh) m
           !t = txs b pl
           !k = keys pl
-      curr <- atomicModifyIORef' count (\n -> (n+1, n+1))
+      atomicModifyIORef' count (\n -> (n+1, ()))
       writes pool b k t
-      when (curr `mod` 1000 == 0) $
-        printf "[INFO] Processed blocks: %d. Progress sample: Chain %d, Height %d\n"
-          curr (_block_chainId b) (_block_height b)
   where
     policy :: RetryPolicyM IO
     policy = exponentialBackoff 250_000 <> limitRetries 3


### PR DESCRIPTION
```
[INFO] Beginning backfill on 10 chains.
[INFO] Progress: 1476/4237910 blocks (0.03%). ~23 hours remaining.
[INFO] Progress: 3014/4237910 blocks (0.07%). ~23 hours remaining.
[INFO] Progress: 4512/4237910 blocks (0.11%). ~23 hours remaining.
```