### PR TITLE
Make transaction table primary key include block hash

### DIFF
--- a/exec/Chainweb/Database.hs
+++ b/exec/Chainweb/Database.hs
@@ -106,6 +106,10 @@ database = unCheckDatabase migratableDb
 -- | Create the DB tables if necessary.
 initializeTables :: Connection -> IO ()
 initializeTables conn = runBeamPostgres conn $
+  liftIO $ putStrLn "Verifying schema..."
   verifySchema migrationBackend migratableDb >>= \case
-    VerificationFailed _ -> autoMigrate migrationBackend migratableDb
-    VerificationSucceeded -> pure ()
+    VerificationFailed _ -> do
+      liftIO $ putStrLn "Migrating schema..."
+      autoMigrate migrationBackend migratableDb
+      liftIO $ putStrLn "Finished migration."
+    VerificationSucceeded -> liftIO $ putStrLn "Schema verified."

--- a/exec/Chainweb/Server.hs
+++ b/exec/Chainweb/Server.hs
@@ -345,7 +345,7 @@ evHandler printLog pool limit offset qSearch qParam qName =
           blk <- all_ (_cddb_blocks database)
           ev <- all_ (_cddb_events database)
           guard_ (_tx_block tx `references_` blk)
-          guard_ (TransactionId (coerce $ _ev_requestkey ev) `references_` tx)
+          guard_ (TransactionId (coerce $ _ev_requestkey ev) (_tx_block tx) `references_` tx)
           whenArg qSearch $ \s -> guard_
             ((_ev_qualName ev `like_` val_ (searchString s)) ||.
              (_ev_paramText ev `like_` val_ (searchString s))

--- a/lib/ChainwebDb/Types/Transaction.hs
+++ b/lib/ChainwebDb/Types/Transaction.hs
@@ -96,7 +96,7 @@ type TransactionId = PrimaryKey TransactionT Identity
 -- deriving instance Ord (PrimaryKey TransactionT Maybe)
 
 instance Table TransactionT where
-  data PrimaryKey TransactionT f = TransactionId { _transactionId :: C f Text }
+  data PrimaryKey TransactionT f = TransactionId (C f Text) (PrimaryKey BlockT f)
     deriving stock (Generic)
     deriving anyclass (Beamable)
-  primaryKey = TransactionId . _tx_requestKey
+  primaryKey tx = TransactionId (_tx_requestKey tx) (_tx_block tx)

--- a/migrations.md
+++ b/migrations.md
@@ -31,3 +31,11 @@ ADD PRIMARY KEY (sourcekey, idx);
 UPDATE events SET sourcetype = 'Source_Tx';
 ```
 
+# 2021-07-16 Expand transactions primary key
+
+```
+BEGIN;
+ALTER TABLE transactions DROP CONSTRAINT transactions_pkey;
+ALTER TABLE transactions ADD PRIMARY KEY (requestkey, block);
+COMMIT;
+```


### PR DESCRIPTION
When orphan transactions are reintroduced the request key alone is not
sufficient to ensure uniqueness.