### PR TITLE
Separate event filling

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -34,8 +34,6 @@ source-repository-package
     subdir:
       gargoyle
       gargoyle-postgresql
-      gargoyle-postgresql-connect
-      gargoyle-postgresql-nix
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -6,7 +6,7 @@ package aeson
 source-repository-package
     type: git
     location: https://github.com/mightybyte/beam-automigrate.git
-    tag: 0fd33d660a523941ad78bcd9869a6e3d9220008e
+    tag: 112c39953c432b05ec6ae2354b0150c61ee30157
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -5,6 +5,11 @@ package aeson
 
 source-repository-package
     type: git
+    location: https://github.com/mightybyte/beam-automigrate.git
+    tag: 0fd33d660a523941ad78bcd9869a6e3d9220008e
+
+source-repository-package
+    type: git
     location: https://github.com/kadena-io/pact.git
     tag: 8681a6d6e72eccefe00100f86202d616ab5d1621
 

--- a/cabal.project
+++ b/cabal.project
@@ -35,6 +35,7 @@ source-repository-package
       gargoyle
       gargoyle-postgresql
       gargoyle-postgresql-connect
+      gargoyle-postgresql-nix
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -34,6 +34,7 @@ source-repository-package
     subdir:
       gargoyle
       gargoyle-postgresql
+      gargoyle-postgresql-connect
 
 source-repository-package
     type: git

--- a/chainweb-data.cabal
+++ b/chainweb-data.cabal
@@ -80,6 +80,7 @@ executable chainweb-data
     , async                    ^>=2.2
     , base16-bytestring
     , base64-bytestring        ^>=1.0
+    , beam-automigrate
     , bytestring
     , cassava                  ^>=0.5
     , cereal                   ^>=0.5

--- a/chainweb-data.cabal
+++ b/chainweb-data.cabal
@@ -28,6 +28,7 @@ common commons
     , base               >=4.7      && <5
     , base-prelude       ^>=1.3
     , base16-bytestring  ^>=0.1
+    , beam-automigrate
     , beam-core          >=0.8 && <0.10
     , beam-migrate       >=0.4 && <0.6
     , beam-postgres      >=0.5 && <0.6
@@ -80,7 +81,6 @@ executable chainweb-data
     , async                    ^>=2.2
     , base16-bytestring
     , base64-bytestring        ^>=1.0
-    , beam-automigrate
     , bytestring
     , cassava                  ^>=0.5
     , cereal                   ^>=0.5

--- a/chainweb-data.cabal
+++ b/chainweb-data.cabal
@@ -122,6 +122,7 @@ executable chainweb-data
     Chainweb.Coins
     Chainweb.Database
     Chainweb.Env
+    Chainweb.FillEvents
     Chainweb.Gaps
     Chainweb.Listen
     Chainweb.Lookups

--- a/default.nix
+++ b/default.nix
@@ -11,9 +11,17 @@ in haskellPackages.developPackage {
   in
   {
     inherit (gargoylePkgs) gargoyle gargoyle-postgresql gargoyle-postgresql-nix gargoyle-postgresql-connect;
+
+    #beam-automigrate = self.callHackageDirect {
+    #  pkg = "beam-automigrate";
+    #  ver = "0.1.2.0";
+    #  sha256 = "1a70da15hb4nlpxhnsy1g89frbpf3kg3mwb4g9carj5izw1w1r1k";
+    #} {};
+
     pact = dontCheck super.pact;
   };
   source-overrides = {
+    beam-automigrate = nix-thunk.thunkSource ./deps/beam-automigrate;
     chainweb-api = nix-thunk.thunkSource ./deps/chainweb-api;
     pact = nix-thunk.thunkSource ./deps/pact;
   };

--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@ in haskellPackages.developPackage {
   let gargoylePkgs = import ./deps/gargoyle { haskellPackages = self; };
   in
   {
-    inherit (gargoylePkgs) gargoyle gargoyle-postgresql gargoyle-postgresql-nix gargoyle-postgresql-connect;
+    inherit (gargoylePkgs) gargoyle gargoyle-postgresql;
 
     #beam-automigrate = self.callHackageDirect {
     #  pkg = "beam-automigrate";

--- a/deps/beam-automigrate/default.nix
+++ b/deps/beam-automigrate/default.nix
@@ -1,0 +1,2 @@
+# DO NOT HAND-EDIT THIS FILE
+import (import ./thunk.nix)

--- a/deps/beam-automigrate/github.json
+++ b/deps/beam-automigrate/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "mightybyte",
   "repo": "beam-automigrate",
-  "branch": "develop",
+  "branch": "no-primary-key-fix",
   "private": false,
-  "rev": "3728df439b0a421bdd0a568c8a6461b4e0e9fdbf",
-  "sha256": "1qs18jny4iv4gzgbz3mlc8d370awq2f5gfip6pc25s2ls1cmbjf9"
+  "rev": "0fd33d660a523941ad78bcd9869a6e3d9220008e",
+  "sha256": "13im8k1kzdinb09zw9n6ljnh7jarm5q8s6ipmzk8c7ayz5gvf1c0"
 }

--- a/deps/beam-automigrate/github.json
+++ b/deps/beam-automigrate/github.json
@@ -3,6 +3,6 @@
   "repo": "beam-automigrate",
   "branch": "no-primary-key-fix",
   "private": false,
-  "rev": "0fd33d660a523941ad78bcd9869a6e3d9220008e",
-  "sha256": "13im8k1kzdinb09zw9n6ljnh7jarm5q8s6ipmzk8c7ayz5gvf1c0"
+  "rev": "112c39953c432b05ec6ae2354b0150c61ee30157",
+  "sha256": "1brn9hx0zczdj8bs7sm821qcrnxx5yb5dm0ifymarj84dbb0n7yk"
 }

--- a/deps/beam-automigrate/github.json
+++ b/deps/beam-automigrate/github.json
@@ -1,0 +1,8 @@
+{
+  "owner": "mightybyte",
+  "repo": "beam-automigrate",
+  "branch": "develop",
+  "private": false,
+  "rev": "3728df439b0a421bdd0a568c8a6461b4e0e9fdbf",
+  "sha256": "1qs18jny4iv4gzgbz3mlc8d370awq2f5gfip6pc25s2ls1cmbjf9"
+}

--- a/deps/beam-automigrate/thunk.nix
+++ b/deps/beam-automigrate/thunk.nix
@@ -1,0 +1,9 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/exec/Chainweb/Backfill.hs
+++ b/exec/Chainweb/Backfill.hs
@@ -23,7 +23,9 @@ import           ChainwebData.Backfill
 import           ChainwebData.Genesis
 import           ChainwebData.Types
 import           ChainwebDb.Types.Block
+import           ChainwebDb.Types.Event
 import           ChainwebDb.Types.DbHash
+import           ChainwebDb.Types.Transaction
 
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async (race_)
@@ -34,10 +36,14 @@ import           Data.ByteString.Lazy (ByteString)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import qualified Data.Pool as P
+import           Data.Tuple.Strict (T2(..))
 import           Data.Witherable.Class (wither)
 
 import           Database.Beam hiding (insert)
+import           Database.Beam.Backend.SQL.BeamExtensions
 import           Database.Beam.Postgres
+import           Database.Beam.Postgres.Full (insert, onConflict)
+import           Database.PostgreSQL.Simple.Transaction (withTransaction, withSavepoint)
 
 ---
 
@@ -48,10 +54,10 @@ backfill env args = do
     Left e -> do
       putStrLn "[FAIL] Error querying cut"
       print e
-    Right cutBS ->
-      if _backfillArgs_onlyEvents args
-        then backfillEventsCut env args cutBS
-        else backfillBlocksCut env args cutBS
+    Right _cutBS -> undefined
+      -- if _backfillArgs_onlyEvents args
+      --   then backfillEventsCut env args cutBS
+      --   else backfillBlocksCut env args cutBS
 
 backfillBlocksCut :: Env -> BackfillArgs -> ByteString -> IO ()
 backfillBlocksCut env args cutBS = do

--- a/exec/Chainweb/Backfill.hs
+++ b/exec/Chainweb/Backfill.hs
@@ -22,38 +22,24 @@ import           Chainweb.Worker
 import           ChainwebData.Backfill
 import           ChainwebData.Genesis
 import           ChainwebData.Types
-import           ChainwebDb.Types.Event
 import           ChainwebDb.Types.Block
-import           ChainwebDb.Types.DbHash
-import           ChainwebDb.Types.Transaction
 
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async (race_)
 import           Control.Scheduler hiding (traverse_)
 
-import           Control.Lens (iforM_)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import qualified Data.Pool as P
-import           Data.Tuple.Strict (T2(..))
 import           Data.Witherable.Class (wither)
 
 import           Database.Beam hiding (insert)
-import           Database.Beam.Backend.SQL.BeamExtensions
 import           Database.Beam.Postgres
-import           Database.Beam.Postgres.Full (insert, onConflict)
-import           Database.PostgreSQL.Simple.Transaction (withTransaction,withSavepoint)
 
 ---
 
 backfill :: Env -> BackfillArgs -> IO ()
 backfill e args = do
-  if _backfillArgs_onlyEvents args
-    then backfillEvents e args
-    else backfillBlocks e args
-
-backfillBlocks :: Env -> BackfillArgs -> IO ()
-backfillBlocks e args = do
   cutBS <- queryCut e
   let curHeight = fromIntegral $ cutMaxHeight cutBS
       cids = atBlockHeight curHeight allCids
@@ -89,87 +75,6 @@ backfillBlocks e args = do
         hs -> traverse_ (writeBlock e pool count) hs
       delayFunc
 
-backfillEvents :: Env -> BackfillArgs -> IO ()
-backfillEvents e args = do
-  cutBS <- queryCut e
-  let curHeight = fromIntegral $ cutMaxHeight cutBS
-      cids = atBlockHeight curHeight allCids
-  counter <- newIORef 0
-
-  missingTxs <- countTxMissingEvents pool
-
-  missingCoinbase <- countCoinbaseTxMissingEvents pool coinbaseEventsActivationHeight
-  if M.null missingTxs && M.null missingCoinbase
-    then do
-      printf "[INFO] There are no events to backfill on any of the %d chains!" (length cids)
-      exitSuccess
-    else do
-      let numTxs = foldl' (+) 0 missingTxs
-          numCoinbase = foldl' (\s h -> s + (h - fromIntegral coinbaseEventsActivationHeight)) 0 missingCoinbase
-
-      printf "[INFO] Beginning event backfill of %d txs on %d chains.\n" numTxs (M.size missingTxs)
-      printf "[INFO] Also beginning event backfill (of coinbase transactions) of %d txs on %d chains.\n" numCoinbase (M.size missingCoinbase)
-      let strat = case delay of
-                    Nothing -> Par'
-                    Just _ -> Seq
-      race_ (progress counter $ fromIntegral (numTxs + numCoinbase))
-        $ traverseConcurrently_ strat (f missingCoinbase counter) cids
-
-  where
-    delay = _backfillArgs_delayMicros args
-    pool = _env_dbConnPool e
-    allCids = _env_chainsAtHeight e
-    delayFunc =
-      case delay of
-        Nothing -> pure ()
-        Just d -> threadDelay d
-    coinbaseEventsActivationHeight = case _nodeInfo_chainwebVer $ _env_nodeInfo e of
-      "mainnet01" -> 1722500
-      "testnet04" -> 1261001
-      _ -> error "Chainweb version: Unknown"
-    f :: Map ChainId Int64 -> IORef Int -> ChainId -> IO ()
-    f missingCoinbase count chain = do
-      blocks <- getTxMissingEvents chain pool (fromMaybe 100 $ _backfillArgs_eventChunkSize args)
-      forM_ blocks $ \(h,(current_hash,ph)) -> do
-        payloadWithOutputs e (T2 chain ph) >>= \case
-          Nothing -> printf "[FAIL] No payload for chain %d, height %d, ph %s\n"
-                            (unChainId chain) h (unDbHash ph)
-          Just bpwo -> do
-            let allTxsEvents = snd $ mkBlockEvents' h chain current_hash bpwo
-                rqKeyEventsMap = allTxsEvents
-                  & mapMaybe (\ev -> fmap (flip (,) 1) (_ev_requestkey ev))
-                  & M.fromListWith (+)
-
-            P.withResource pool $ \c ->
-              withTransaction c $ do
-                runBeamPostgres c $ do
-                  runInsert
-                    $ insert (_cddb_events database) (insertValues allTxsEvents)
-                    $ onConflict (conflictingFields primaryKey) onConflictDoNothing
-                withSavepoint c $ runBeamPostgres c $
-                  iforM_ rqKeyEventsMap $ \reqKey num_events ->
-                    runUpdate
-                      $ update (_cddb_transactions database)
-                          (\tx -> _tx_numEvents tx <-. val_ (Just num_events))
-                          (\tx -> _tx_requestKey tx ==. val_ (unDbHash reqKey))
-            atomicModifyIORef' count (\n -> (n+1, ()))
-
-      forM_ (M.lookup chain missingCoinbase) $ \minheight -> do
-        coinbaseBlocks <- getCoinbaseMissingEvents chain (fromIntegral coinbaseEventsActivationHeight) minheight pool
-        forM_ coinbaseBlocks $ \(h, (current_hash, ph)) -> do
-          payloadWithOutputs e (T2 chain ph) >>= \case
-            Nothing -> printf "[FAIL] No payload for chain %d, height %d, ph %s\n"
-                            (unChainId chain) h (unDbHash ph)
-            Just bpwo -> do
-              P.withResource pool $ \c -> runBeamPostgres c $
-                runInsert
-                  $ insert (_cddb_events database) (insertValues $ fst $ mkBlockEvents' h chain current_hash bpwo)
-                  $ onConflict (conflictingFields primaryKey) onConflictDoNothing
-              atomicModifyIORef' count (\n -> (n+1, ()))
-          forM_ delay threadDelay
-
-      delayFunc
-
 -- | For all blocks written to the DB, find the shortest (in terms of block
 -- height) for each chain.
 minHeights :: [ChainId] -> P.Pool Connection -> IO (Map ChainId Int)
@@ -187,65 +92,3 @@ minHeights cids pool = M.fromList <$> wither selectMinHeight cids
       $ filter_ (\b -> _block_chainId b ==. val_ (fromIntegral cid))
       $ all_ (_cddb_blocks database)
 
--- | For all blocks written to the DB, find the shortest (in terms of block
--- height) for each chain.
-countTxMissingEvents :: P.Pool Connection -> IO (Map ChainId Int64)
-countTxMissingEvents pool = do
-    chainCounts <- P.withResource pool $ \c -> runBeamPostgres c $
-      runSelectReturningList $
-      select $
-      aggregate_ agg $ do
-        tx <- all_ (_cddb_transactions database)
-        blk <- all_ (_cddb_blocks database)
-        guard_ (_tx_block tx `references_` blk &&. _tx_numEvents tx ==. val_ Nothing)
-        return (_block_chainId blk, _tx_requestKey tx)
-    return $ M.fromList $ map (\(cid,cnt) -> (ChainId $ fromIntegral cid, cnt)) chainCounts
-  where
-    agg (cid, rk) = (group_ cid, as_ @Int64 $ countOver_ distinctInGroup_ rk)
-
-{- We only need to go back so far to search for events in coinbase transactions -}
-countCoinbaseTxMissingEvents :: P.Pool Connection -> Integer -> IO (Map ChainId Int64)
-countCoinbaseTxMissingEvents pool eventsActivationHeight = do
-    chainCounts <- P.withResource pool $ \c -> runBeamPostgres c $
-      runSelectReturningList $
-      select $
-      aggregate_ agg $ do
-        event <- all_ (_cddb_events database)
-        guard_ (_ev_height event >=. val_ (fromIntegral eventsActivationHeight))
-        return (_ev_chainid event, _ev_height event)
-    return $ M.mapMaybe id $ M.fromList $ map (first $ ChainId . fromIntegral) chainCounts
-  where
-    agg (cid, height) = (group_ cid, as_ @(Maybe Int64) $ min_ height)
-
-getCoinbaseMissingEvents :: ChainId -> Int64 -> Int64 -> P.Pool Connection -> IO [(Int64, (DbHash BlockHash, DbHash PayloadHash))]
-getCoinbaseMissingEvents chain eventsActivationHeight minHeight pool =
-    P.withResource pool $ \c -> runBeamPostgres c $
-    runSelectReturningList $
-    select $
-    orderBy_ (desc_ . fst) $ nub_ $ do
-      blk <- all_ (_cddb_blocks database)
-      guard_ $ _block_height blk >=. val_ eventsActivationHeight
-                &&. _block_height blk <. val_ minHeight
-                &&. _block_chainId blk ==. val_ cid
-      return $ (_block_height blk, (_block_hash blk, _block_payload blk))
-  where
-    cid :: Int64
-    cid = fromIntegral $ unChainId chain
-
--- | Get the highest lim blocks with transactions that have unfilled events
-getTxMissingEvents :: ChainId -> P.Pool Connection -> Integer -> IO [(Int64, (DbHash BlockHash, DbHash PayloadHash))]
-getTxMissingEvents chain pool lim = do
-    P.withResource pool $ \c -> runBeamPostgres c $
-      runSelectReturningList $
-      select $
-      limit_ lim $
-      orderBy_ (desc_ . fst) $ nub_ $ do
-        tx <- all_ (_cddb_transactions database)
-        blk <- all_ (_cddb_blocks database)
-        guard_ (_tx_block tx `references_` blk &&.
-                _tx_numEvents tx ==. val_ Nothing &&.
-                _block_chainId blk ==. val_ cid)
-        return (_block_height blk, (_block_hash blk, _block_payload blk))
-  where
-    cid :: Int64
-    cid = fromIntegral $ unChainId chain

--- a/exec/Chainweb/Backfill.hs
+++ b/exec/Chainweb/Backfill.hs
@@ -23,6 +23,7 @@ import           ChainwebData.Backfill
 import           ChainwebData.Genesis
 import           ChainwebData.Types
 import           ChainwebDb.Types.Block
+import           ChainwebDb.Types.DbHash
 
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async (race_)

--- a/exec/Chainweb/Database.hs
+++ b/exec/Chainweb/Database.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Chainweb.Database
@@ -18,24 +20,32 @@ module Chainweb.Database
 
 import           Chainweb.Env
 import           ChainwebDb.Types.Block
+import           ChainwebDb.Types.DbHash
 import           ChainwebDb.Types.MinerKey
 import           ChainwebDb.Types.Transaction
 import           ChainwebDb.Types.Event
-import qualified Control.Monad.Fail as Fail
 import qualified Data.Pool as P
+import           Data.Proxy
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.String
 import           Database.Beam
-import           Database.Beam.Migrate
-import           Database.Beam.Migrate.Backend
-import           Database.Beam.Migrate.Simple
+import qualified Database.Beam.AutoMigrate as BA
+import           Database.Beam.AutoMigrate.Types
+import           Database.Beam.Backend.SQL hiding (tableName)
 import           Database.Beam.Postgres
-import           Database.Beam.Postgres.Migrate (migrationBackend)
-import           Database.Beam.Postgres.Syntax
-import           System.Logger
+import           System.Exit
+import           System.Logger hiding (logg)
 
 ---
+
+instance BA.HasColumnType (DbHash a) where
+  defaultColumnType _ = SqlStdType $ varCharType Nothing Nothing
+  defaultTypeCast _ = Just "character varying"
+
+instance BA.HasColumnType HashAsNum where
+  defaultColumnType _ = SqlStdType $ numericType (Just (80, Nothing))
+  defaultTypeCast _ = Just "numeric"
 
 data ChainwebDataDb f = ChainwebDataDb
   { _cddb_blocks :: f (TableEntity BlockT)
@@ -49,9 +59,10 @@ data ChainwebDataDb f = ChainwebDataDb
 modTableName :: Text -> Text
 modTableName = T.takeWhileEnd (/= '_')
 
-migratableDb :: CheckedDatabaseSettings Postgres ChainwebDataDb
-migratableDb = defaultMigratableDbSettings `withDbModification` dbModification
-  { _cddb_blocks = modifyCheckedTable modTableName checkedTableModification
+database :: DatabaseSettings be ChainwebDataDb
+database = defaultDbSettings `withDbModification` dbModification
+  { _cddb_blocks = modifyEntityName modTableName <>
+    modifyTableFields tableModification
     { _block_creationTime = "creationtime"
     , _block_chainId = "chainid"
     , _block_height = "height"
@@ -67,7 +78,8 @@ migratableDb = defaultMigratableDbSettings `withDbModification` dbModification
     , _block_miner_acc = "miner"
     , _block_miner_pred = "predicate"
     }
-  , _cddb_transactions = modifyCheckedTable modTableName checkedTableModification
+  , _cddb_transactions = modifyEntityName modTableName <>
+    modifyTableFields tableModification
     { _tx_chainId = "chainid"
     , _tx_block = BlockId "block"
     , _tx_creationTime = "creationtime"
@@ -93,11 +105,13 @@ migratableDb = defaultMigratableDbSettings `withDbModification` dbModification
     , _tx_txid = "txid"
     , _tx_numEvents = "num_events"
     }
-  , _cddb_minerkeys = modifyCheckedTable modTableName checkedTableModification
+  , _cddb_minerkeys = modifyEntityName modTableName <>
+    modifyTableFields tableModification
     { _minerKey_block = BlockId "block"
     , _minerKey_key = "key"
     }
-  , _cddb_events = modifyCheckedTable modTableName checkedTableModification
+  , _cddb_events = modifyEntityName modTableName <>
+    modifyTableFields tableModification
     { _ev_requestkey = "requestkey"
     , _ev_block = "block"
     , _ev_chainid = "chainid"
@@ -112,69 +126,37 @@ migratableDb = defaultMigratableDbSettings `withDbModification` dbModification
     }
   }
 
-database :: DatabaseSettings Postgres ChainwebDataDb
-database = unCheckDatabase migratableDb
+annotatedDb :: BA.AnnotatedDatabaseSettings be ChainwebDataDb
+annotatedDb = BA.defaultAnnotatedDbSettings database
+
+hsSchema :: BA.Schema
+hsSchema = BA.fromAnnotatedDbSettings annotatedDb (Proxy @'[])
+
+showMigration :: Connection -> IO ()
+showMigration conn =
+  runBeamPostgres conn $
+    BA.printMigration $ BA.migrate conn hsSchema
 
 -- | Create the DB tables if necessary.
-initializeTables :: LogFunctionIO Text -> Connection -> IO ()
-initializeTables logger conn = runBeamPostgresDebug (logger Debug . fromString) conn $ do
-  liftIO $ logger Info "Verifying schema..."
-  verifySchema migrationBackend migratableDb >>= \case
-    VerificationFailed ps -> do
-      liftIO $ do
-        logger Info "The following schema predicates need to be satisfied:"
-        mapM_ (logger Info . fromString . show) ps
-        logger Info "Migrating schema..."
-      ourMigrate logger migrationBackend migratableDb
-      liftIO $ logger Info "Finished migration."
-    VerificationSucceeded -> liftIO $ logger Info "Schema verified."
-
-ourMigrate
-  :: forall db m.
-     (Database Postgres db,
-      Fail.MonadFail m,
-      MonadIO m)
-  => LogFunctionIO Text
-  -> BeamMigrationBackend Postgres m
-  -> CheckedDatabaseSettings Postgres db
-  -> m ()
-ourMigrate logger BeamMigrationBackend { backendActionProvider = actions
-                                 , backendGetDbConstraints = getCs }
-           db = do
-    liftIO $ logger Info "Calling getCs"
-    actual <- getCs
-    liftIO $ logger Info "Collecting checks"
-    let expected = collectChecks db
-    liftIO $ logger Info "Running heuristic solver"
-    let !solver = heuristicSolver actions actual expected
-    case solver of
-      ProvideSolution _ -> liftIO $ logger Info "hueristicSolver returned ProvideSolution"
-      SearchFailed _ -> liftIO $ logger Info "hueristicSolver returned SearchFailed"
-      ChooseActions _ mkac fs _ -> liftIO $ do
-        logger Info "hueristicSolver returned ChooseActions"
-        mapM_ (logger Info . actionEnglish . mkac) fs
-    liftIO $ logger Info "Calculationg final solution"
-    case finalSolution solver of
-      Candidates {} -> Fail.fail "autoMigrate: Could not determine migration"
-      Solved cmds -> do
-        -- Check if any of the commands are irreversible
-        liftIO $ logger Info "Folding over migration commands"
-        case foldMap migrationCommandDataLossPossible cmds of
-          MigrationKeepsData -> do
-            liftIO $ do
-              logger Info "Will run the following migration steps:"
-              mapM_ (logger Info . fromString . show . fromPgCommand . migrationCommand) cmds
-            mapM_ doStep cmds
-          _ -> Fail.fail "autoMigrate: Not performing automatic migration due to data loss"
-  where
-    doStep :: MigrationCommand Postgres -> m ()
-    --doStep c = runNoReturn (migrationCommand c)
-    doStep c = do
-      let s = migrationCommand c
-      liftIO $ do
-        logger Info "Executing step:"
-        logger Info $ fromString $ show $ fromPgCommand s
-      runNoReturn s
+initializeTables :: LogFunctionIO Text -> MigrateStatus -> Connection -> IO ()
+initializeTables logg migrateStatus conn = do
+  diff <- BA.calcMigrationSteps annotatedDb conn
+  case diff of
+    Left err -> do
+        logg Error "Error detecting database migration requirements: "
+        logg Error $ fromString $ show err
+    Right [] -> logg Info "No database migration needed.  Continuing..."
+    Right _ -> do
+      logg Info "Database migration needed."
+      case migrateStatus of
+        RunMigration -> do
+          logg Info "Running the following migration:"
+          showMigration conn
+          BA.tryRunMigrationsWithEditUpdate annotatedDb conn
+        DontMigrate -> do
+          logg Info "Database needs to be migrated.  Re-run with the -m option or you can migrate by hand with the following query:"
+          showMigration conn
+          exitFailure
 
 withDb :: Env -> Pg b -> IO b
 withDb env qry = P.withResource (_env_dbConnPool env) $ \c -> runBeamPostgres c qry

--- a/exec/Chainweb/Database.hs
+++ b/exec/Chainweb/Database.hs
@@ -20,7 +20,6 @@ module Chainweb.Database
 
 import           Chainweb.Env
 import           ChainwebDb.Types.Block
-import           ChainwebDb.Types.DbHash
 import           ChainwebDb.Types.MinerKey
 import           ChainwebDb.Types.Transaction
 import           ChainwebDb.Types.Event
@@ -31,21 +30,11 @@ import qualified Data.Text as T
 import           Data.String
 import           Database.Beam
 import qualified Database.Beam.AutoMigrate as BA
-import           Database.Beam.AutoMigrate.Types
-import           Database.Beam.Backend.SQL hiding (tableName)
 import           Database.Beam.Postgres
 import           System.Exit
 import           System.Logger hiding (logg)
 
 ---
-
-instance BA.HasColumnType (DbHash a) where
-  defaultColumnType _ = SqlStdType $ varCharType Nothing Nothing
-  defaultTypeCast _ = Just "character varying"
-
-instance BA.HasColumnType HashAsNum where
-  defaultColumnType _ = SqlStdType $ numericType (Just (80, Nothing))
-  defaultTypeCast _ = Just "numeric"
 
 data ChainwebDataDb f = ChainwebDataDb
   { _cddb_blocks :: f (TableEntity BlockT)

--- a/exec/Chainweb/Database.hs
+++ b/exec/Chainweb/Database.hs
@@ -11,13 +11,18 @@ module Chainweb.Database
   ( ChainwebDataDb(..)
   , database
   , initializeTables
+
+  , withDb
+  , withDbDebug
   ) where
 
+import           Chainweb.Env
 import           ChainwebDb.Types.Block
 import           ChainwebDb.Types.MinerKey
 import           ChainwebDb.Types.Transaction
 import           ChainwebDb.Types.Event
 import qualified Control.Monad.Fail as Fail
+import qualified Data.Pool as P
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.String
@@ -171,3 +176,8 @@ ourMigrate logger BeamMigrationBackend { backendActionProvider = actions
         logger Info $ fromString $ show $ fromPgCommand s
       runNoReturn s
 
+withDb :: Env -> Pg b -> IO b
+withDb env qry = P.withResource (_env_dbConnPool env) $ \c -> runBeamPostgres c qry
+
+withDbDebug :: Env -> LogLevel -> Pg b -> IO b
+withDbDebug env level qry = P.withResource (_env_dbConnPool env) $ \c -> runBeamPostgresDebug (liftIO . _env_logger env level . fromString) c qry

--- a/exec/Chainweb/Env.hs
+++ b/exec/Chainweb/Env.hs
@@ -51,7 +51,7 @@ import           Network.HTTP.Client (Manager)
 import           Options.Applicative
 import qualified Servant.Client as S
 import           System.IO
-import           System.Logger.Types
+import           System.Logger.Types hiding (logg)
 import           Text.Printf
 
 ---
@@ -269,8 +269,8 @@ commands = hsubparser
        (progDesc "Event Worker - Fills missing events"))
   )
 
-progress :: IORef Int -> Int -> IO a
-progress count total = do
+progress :: LogFunctionIO Text -> IORef Int -> Int -> IO a
+progress logg count total = do
   start <- getPOSIXTime
   forever $ do
     threadDelay 30_000_000  -- 30 seconds. TODO Make configurable?
@@ -282,7 +282,7 @@ progress count total = do
         estMinutesLeft = floor (fromIntegral (total - completed) / blocksPerMinute) :: Int
         (timeUnits, timeLeft) | estMinutesLeft < 60 = ("minutes" :: String, estMinutesLeft)
                               | otherwise = ("hours", estMinutesLeft `div` 60)
-    printf "[INFO] Progress: %d/%d (%.2f%%), ~%d %s remaining at %.0f items per minute.\n"
+    logg Info $ fromString $ printf "Progress: %d/%d (%.2f%%), ~%d %s remaining at %.0f items per minute."
       completed total perc timeLeft timeUnits blocksPerMinute
     hFlush stdout
 

--- a/exec/Chainweb/Env.hs
+++ b/exec/Chainweb/Env.hs
@@ -3,7 +3,8 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 module Chainweb.Env
-  ( Args(..)
+  ( MigrateStatus(..)
+  , Args(..)
   , Env(..)
   , chainStartHeights
   , ServerEnv(..)
@@ -56,8 +57,11 @@ import           Text.Printf
 
 ---
 
+data MigrateStatus = RunMigration | DontMigrate
+  deriving (Eq,Ord,Show,Read)
+
 data Args
-  = Args Command Connect UrlScheme Url LogLevel
+  = Args Command Connect UrlScheme Url LogLevel MigrateStatus
     -- ^ arguments for the Listen, Backfill, Gaps, Single,
     -- and Server cmds
   | RichListArgs NodeDbPath LogLevel
@@ -185,6 +189,11 @@ envP = Args
   <*> urlSchemeParser "service" 1848
   <*> urlParser "p2p" 443
   <*> logLevelParser
+  <*> migrationP
+
+migrationP :: Parser MigrateStatus
+migrationP =
+  flag DontMigrate RunMigration (short 'm' <> long "migrate" <> help "Run DB migration")
 
 logLevelParser :: Parser LogLevel
 logLevelParser =

--- a/exec/Chainweb/Env.hs
+++ b/exec/Chainweb/Env.hs
@@ -179,7 +179,6 @@ data BackfillArgs = BackfillArgs
 
 data ServerEnv = ServerEnv
   { _serverEnv_port :: Int
-  , _serverEnv_verbose :: Bool
   } deriving (Eq,Ord,Show)
 
 envP :: Parser Args
@@ -245,7 +244,6 @@ singleP = Single
 serverP :: Parser ServerEnv
 serverP = ServerEnv
   <$> option auto (long "port" <> metavar "INT" <> help "Port the server will listen on")
-  <*> switch (short 'v' <> help "Verbose mode that shows when headers come in")
 
 delayP :: Parser (Maybe Int)
 delayP = optional $ option auto (long "delay" <> metavar "DELAY_MICROS" <> help  "Number of microseconds to delay between queries to the node")

--- a/exec/Chainweb/FillEvents.hs
+++ b/exec/Chainweb/FillEvents.hs
@@ -1,0 +1,230 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Chainweb.FillEvents
+( fillEvents
+) where
+
+
+import           BasePrelude hiding (insert, range, second)
+
+import           Chainweb.Api.ChainId (ChainId(..))
+import           Chainweb.Api.Common
+import           Chainweb.Api.NodeInfo
+import           Chainweb.Database
+import           Chainweb.Env
+import           Chainweb.Lookups
+import           ChainwebDb.Types.Event
+import           ChainwebDb.Types.Block
+import           ChainwebDb.Types.DbHash
+import           ChainwebDb.Types.Transaction
+
+import           Control.Concurrent (threadDelay)
+import           Control.Concurrent.Async (race_)
+import           Control.Scheduler hiding (traverse_)
+
+import           Control.Lens (iforM_)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import qualified Data.Pool as P
+import           Data.Tuple.Strict (T2(..))
+
+import           Database.Beam hiding (insert)
+import           Database.Beam.Backend.SQL.BeamExtensions
+import           Database.Beam.Postgres
+import           Database.Beam.Postgres.Full (insert, onConflict)
+import           Database.PostgreSQL.Simple.Transaction (withTransaction,withSavepoint)
+
+---
+
+fillEvents :: Env -> BackfillArgs -> EventType -> IO ()
+fillEvents e args et = do
+  gaps <- getEventGaps e
+  mapM_ print gaps
+  printf "Got %d gaps\n" (length gaps)
+--  cutBS <- queryCut e
+--  let curHeight = fromIntegral $ cutMaxHeight cutBS
+--      cids = atBlockHeight curHeight allCids
+--  counter <- newIORef 0
+--
+--  when (et == CoinbaseAndTx) $ do
+--    missingCoinbase <- countCoinbaseTxMissingEvents pool coinbaseEventsActivationHeight
+--    if M.null missingTxs && M.null missingCoinbase
+--      then do
+--        printf "[INFO] There are no events to backfill on any of the %d chains!" (length cids)
+--        exitSuccess
+--      else do
+--        let numTxs = foldl' (+) 0 missingTxs
+--            numCoinbase = foldl' (\s h -> s + (h - fromIntegral coinbaseEventsActivationHeight)) 0 missingCoinbase
+--
+--        printf "[INFO] Beginning event backfill of %d txs on %d chains.\n" numTxs (M.size missingTxs)
+--        printf "[INFO] Also beginning event backfill (of coinbase transactions) of %d txs on %d chains.\n" numCoinbase (M.size missingCoinbase)
+--        let strat = case delay of
+--                      Nothing -> Par'
+--                      Just _ -> Seq
+--        race_ (progress counter $ fromIntegral (numTxs + numCoinbase))
+--          $ traverseConcurrently_ strat (f missingCoinbase counter) cids
+--
+--  missingTxs <- countTxMissingEvents pool
+--
+--  where
+--    delay = _backfillArgs_delayMicros args
+--    pool = _env_dbConnPool e
+--    allCids = _env_chainsAtHeight e
+--    delayFunc =
+--      case delay of
+--        Nothing -> pure ()
+--        Just d -> threadDelay d
+--    coinbaseEventsActivationHeight = case _nodeInfo_chainwebVer $ _env_nodeInfo e of
+--      "mainnet01" -> 1722500
+--      "testnet04" -> 1261001
+--      _ -> error "Chainweb version: Unknown"
+--    f :: Map ChainId Int64 -> IORef Int -> ChainId -> IO ()
+--    f missingCoinbase count chain = do
+--      blocks <- getTxMissingEvents chain pool (fromMaybe 100 $ _backfillArgs_eventChunkSize args)
+--      forM_ blocks $ \(h,(current_hash,ph)) -> do
+--        payloadWithOutputs e (T2 chain ph) >>= \case
+--          Nothing -> printf "[FAIL] No payload for chain %d, height %d, ph %s\n"
+--                            (unChainId chain) h (unDbHash ph)
+--          Just bpwo -> do
+--            let allTxsEvents = snd $ mkBlockEvents' h chain current_hash bpwo
+--                rqKeyEventsMap = allTxsEvents
+--                  & mapMaybe (\ev -> fmap (flip (,) 1) (_ev_requestkey ev))
+--                  & M.fromListWith (+)
+--
+--            P.withResource pool $ \c ->
+--              withTransaction c $ do
+--                runBeamPostgres c $ do
+--                  runInsert
+--                    $ insert (_cddb_events database) (insertValues allTxsEvents)
+--                    $ onConflict (conflictingFields primaryKey) onConflictDoNothing
+--                withSavepoint c $ runBeamPostgres c $
+--                  iforM_ rqKeyEventsMap $ \reqKey num_events ->
+--                    runUpdate
+--                      $ update (_cddb_transactions database)
+--                          (\tx -> _tx_numEvents tx <-. val_ (Just num_events))
+--                          (\tx -> _tx_requestKey tx ==. val_ (unDbHash reqKey))
+--            atomicModifyIORef' count (\n -> (n+1, ()))
+--
+--      forM_ (M.lookup chain missingCoinbase) $ \minheight -> do
+--        coinbaseBlocks <- getCoinbaseMissingEvents chain (fromIntegral coinbaseEventsActivationHeight) minheight pool
+--        forM_ coinbaseBlocks $ \(h, (current_hash, ph)) -> do
+--          payloadWithOutputs e (T2 chain ph) >>= \case
+--            Nothing -> printf "[FAIL] No payload for chain %d, height %d, ph %s\n"
+--                            (unChainId chain) h (unDbHash ph)
+--            Just bpwo -> do
+--              P.withResource pool $ \c -> runBeamPostgres c $
+--                runInsert
+--                  $ insert (_cddb_events database) (insertValues $ fst $ mkBlockEvents' h chain current_hash bpwo)
+--                  $ onConflict (conflictingFields primaryKey) onConflictDoNothing
+--              atomicModifyIORef' count (\n -> (n+1, ()))
+--          forM_ delay threadDelay
+--
+--      delayFunc
+--
+---- | For all blocks written to the DB, find the shortest (in terms of block
+---- height) for each chain.
+--countTxMissingEvents :: P.Pool Connection -> IO (Map ChainId Int64)
+--countTxMissingEvents pool = do
+--    chainCounts <- P.withResource pool $ \c -> runBeamPostgres c $
+--      runSelectReturningList $
+--      select $
+--      aggregate_ agg $ do
+--        tx <- all_ (_cddb_transactions database)
+--        blk <- all_ (_cddb_blocks database)
+--        guard_ (_tx_block tx `references_` blk &&. _tx_numEvents tx ==. val_ Nothing)
+--        return (_block_chainId blk, _tx_requestKey tx)
+--    return $ M.fromList $ map (\(cid,cnt) -> (ChainId $ fromIntegral cid, cnt)) chainCounts
+--  where
+--    agg (cid, rk) = (group_ cid, as_ @Int64 $ countOver_ distinctInGroup_ rk)
+--
+--{- We only need to go back so far to search for events in coinbase transactions -}
+--countCoinbaseTxMissingEvents :: P.Pool Connection -> Integer -> IO (Map ChainId Int64)
+--countCoinbaseTxMissingEvents pool eventsActivationHeight = do
+--    chainCounts <- P.withResource pool $ \c -> runBeamPostgres c $
+--      runSelectReturningList $
+--      select $
+--      aggregate_ agg $ do
+--        event <- all_ (_cddb_events database)
+--        guard_ (_ev_height event >=. val_ (fromIntegral eventsActivationHeight))
+--        return (_ev_chainid event, _ev_height event)
+--    return $ M.mapMaybe id $ M.fromList $ map (first $ ChainId . fromIntegral) chainCounts
+--  where
+--    agg (cid, height) = (group_ cid, as_ @(Maybe Int64) $ min_ height)
+--
+--getCoinbaseMissingEvents :: ChainId -> Int64 -> Int64 -> P.Pool Connection -> IO [(Int64, (DbHash BlockHash, DbHash PayloadHash))]
+--getCoinbaseMissingEvents chain eventsActivationHeight minHeight pool =
+--    P.withResource pool $ \c -> runBeamPostgres c $
+--    runSelectReturningList $
+--    select $
+--    orderBy_ (desc_ . fst) $ nub_ $ do
+--      blk <- all_ (_cddb_blocks database)
+--      guard_ $ _block_height blk >=. val_ eventsActivationHeight
+--                &&. _block_height blk <. val_ minHeight
+--                &&. _block_chainId blk ==. val_ cid
+--      return $ (_block_height blk, (_block_hash blk, _block_payload blk))
+--  where
+--    cid :: Int64
+--    cid = fromIntegral $ unChainId chain
+--
+---- | Get the highest lim blocks with transactions that have unfilled events
+--getTxMissingEvents :: ChainId -> P.Pool Connection -> Integer -> IO [(Int64, (DbHash BlockHash, DbHash PayloadHash))]
+--getTxMissingEvents chain pool lim = do
+--    P.withResource pool $ \c -> runBeamPostgres c $
+--      runSelectReturningList $
+--      select $
+--      limit_ lim $
+--      orderBy_ (desc_ . fst) $ nub_ $ do
+--        tx <- all_ (_cddb_transactions database)
+--        blk <- all_ (_cddb_blocks database)
+--        guard_ (_tx_block tx `references_` blk &&.
+--                _tx_numEvents tx ==. val_ Nothing &&.
+--                _block_chainId blk ==. val_ cid)
+--        return (_block_height blk, (_block_hash blk, _block_payload blk))
+--  where
+--    cid :: Int64
+--    cid = fromIntegral $ unChainId chain
+--
+--coinbaseEventGaps = 
+--    "with gaps as \
+--    \(select chainid, height, LEAD (height,1) \
+--    \OVER (PARTITION BY chainid ORDER BY height ASC) \
+--    \AS next_height from blocks group by chainid, height) \
+--    \select * from gaps where next_height - height > 1;"
+--
+--
+--withGaps :: P.Pool Connection -> ((Int, BlockHeight, BlockHeight) -> IO ()) -> IO ()
+--withGaps pool f = P.withResource pool $ \c ->
+--    join $ fold_
+--      c
+--      queryString
+--      (printf "[INFO] No gaps detected.\n")
+--      (\_ x -> pure $ f x)
+--  where
+--    queryString =
+--      "with gaps as (select chainid, height, LEAD (height,1) OVER (PARTITION BY chainid ORDER BY height ASC) AS next_height from events group by chainid, height) select * from gaps where next_height - height > 1;"
+
+getEventGaps :: Env -> IO [(Int64, Int64, Int64)]
+getEventGaps env = P.withResource (_env_dbConnPool env) $ \c -> runBeamPostgresDebug putStrLn c $ do
+  runSelectReturningList $
+    select $
+    orderBy_ (\(h,a,b) -> desc_ a) $
+    withWindow_ (\e -> frame_ (partitionBy_ (_ev_chainid e)) (orderPartitionBy_ $ asc_ $ _ev_height e) noBounds_)
+                (\e w -> (_ev_chainid e, _ev_height e, lead_ (_ev_height e) (val_ (1 :: Int64)) `over_` w))
+                (all_ $ _cddb_events database)
+
+--  runSelectReturningList
+--    $ select
+--    $ do
+--      res@(chain, height, nextHeight) <-
+--        orderBy_ (asc_ . snd) $
+--        aggregate_ (\(c,h) -> (group_ (c,h), lead1_ h)) $
+--        withWindow_ (\e -> frame_ (partitionBy_ (_ev_chainid e)) (orderPartitionBy_ $ asc_ $ _ev_height e) noBounds_)
+--                    (\e w -> (_ev_chainid e, ev_height e, lead_ (_ev_height e) (val_ 1) `over_` w))
+--                    (all_ $ _cddb_events database)
+--      guard_ (nextHeight - height >. val_ 1)
+--      pure res

--- a/exec/Chainweb/FillEvents.hs
+++ b/exec/Chainweb/FillEvents.hs
@@ -19,6 +19,7 @@ import           Chainweb.Api.NodeInfo
 import           Chainweb.Database
 import           Chainweb.Env
 import           Chainweb.Lookups
+import           Chainweb.Worker
 import           ChainwebData.Types
 import           ChainwebDb.Types.Block
 import           ChainwebDb.Types.Event
@@ -28,16 +29,13 @@ import           ChainwebDb.Types.Transaction
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async (race_)
 
-import           Control.Lens (iforM_)
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.Map.Strict as M
 import qualified Data.Pool as P
 
 import           Database.Beam hiding (insert)
-import           Database.Beam.Backend.SQL.BeamExtensions
 import           Database.Beam.Postgres
-import           Database.Beam.Postgres.Full (insert, onConflict)
-import           Database.PostgreSQL.Simple.Transaction (withTransaction,withSavepoint)
+import           Database.PostgreSQL.Simple.Transaction
 
 import           System.Logger.Types hiding (logg)
 
@@ -49,39 +47,48 @@ fillEvents env args et = do
   case ecut of
     Left e -> do
       let logg = _env_logger env
-      logg Error $ fromString $ printf "[FAIL] Error querying cut"
+      logg Error $ fromString $ printf "Error querying cut"
       logg Error $ fromString $ show e
     Right cutBS -> fillEventsCut env args et cutBS
 
 fillEventsCut :: Env -> BackfillArgs -> EventType -> ByteString -> IO ()
 fillEventsCut env args et cutBS = do
   let curHeight = cutMaxHeight cutBS
+      cids = atBlockHeight (fromIntegral curHeight) allCids
+
+  minHeights <- withDbDebug env Debug chainMinHeights
+  let count = length minHeights
+  when (count /= length cids) $ do
+    logg Error $ fromString $ printf "%d chains have event data, but we expected %d." count (length cids)
+    logg Error $ fromString $ printf "Please run 'listen' or 'server' first, and ensure that each chain has a least one event."
+    logg Error $ fromString $ printf "That should take about a minute, after which you can rerun this command."
+    exitFailure
 
   counter <- newIORef 0
 
   when (et == CoinbaseAndTx) $ do
     let startingHeight = case _nodeInfo_chainwebVer $ _env_nodeInfo env of
-          "mainnet01" -> 1722500
+          "mainnet01" -> 1722501
           "testnet04" -> 1261001
           _ -> error "Chainweb version: Unknown"
     gaps <- getCoinbaseGaps env startingHeight
     mapM_ (logg Debug . fromString . show) gaps
     let numMissingCoinbase = sum $ map (\(_,a,b) -> b - a - 1) gaps
-    logg Info $ fromString $ printf "Got %d gaps\n" (length gaps)
+    logg Info $ fromString $ printf "Got %d gaps" (length gaps)
 
     if null gaps
       then do
-        logg Info "[INFO] There are no missing coinbase events on any of the chains!"
+        logg Info "There are no missing coinbase events on any of the chains!"
         exitSuccess
       else do
-        logg Info $ fromString $ printf "[INFO] Filling coinbase transactions of %d blocks.\n" numMissingCoinbase
-        race_ (progress counter $ fromIntegral numMissingCoinbase) $ do
+        logg Info $ fromString $ printf "Filling coinbase transactions of %d blocks." numMissingCoinbase
+        race_ (progress logg counter $ fromIntegral numMissingCoinbase) $ do
           forM gaps $ \(chain, low, high) -> do
             -- TODO Maybe make the chunk size configurable
             forM (rangeToDescGroupsOf 100 (Low $ fromIntegral low) (High $ fromIntegral high)) $ \(chunkLow, chunkHigh) -> do
               headersBetween env (ChainId $ fromIntegral chain, chunkLow, chunkHigh) >>= \case
-                Left e -> logg Error $ fromString $ printf "[FAIL] ApiError for range %s: %s\n" (show (chunkLow, chunkHigh)) (show e)
-                Right [] -> logg Error $ fromString $ printf "[FAIL] headersBetween: %s\n" $ show (chunkLow, chunkHigh)
+                Left e -> logg Error $ fromString $ printf "ApiError for range %s: %s" (show (chunkLow, chunkHigh)) (show e)
+                Right [] -> logg Error $ fromString $ printf "headersBetween: %s" $ show (chunkLow, chunkHigh)
                 Right headers -> do
                   let payloadHashes = M.fromList $ map (\header -> (hashToDbHash $ _blockHeader_payloadHash header, header)) headers
                   payloadWithOutputsBatch env (ChainId $ fromIntegral chain) payloadHashes >>= \case
@@ -90,7 +97,7 @@ fillEventsCut env args et cutBS = do
                       if (apiError_type e == ClientError)
                         then do
                           forM_ (filter (\header -> curHeight - (fromIntegral $ _blockHeader_height header) > 120) headers) $ \header -> do
-                            logg Debug $ fromString $ printf "[DEBUG] Setting numEvents to 0 for all transactions with block hash %s\n" (unDbHash $ hashToDbHash $ _blockHeader_hash header)
+                            logg Debug $ fromString $ printf "Setting numEvents to 0 for all transactions with block hash %s" (unDbHash $ hashToDbHash $ _blockHeader_hash header)
                             P.withResource pool $ \c ->
                               withTransaction c $ runBeamPostgres c $
                                 runUpdate
@@ -98,59 +105,46 @@ fillEventsCut env args et cutBS = do
                                     (\tx -> _tx_numEvents tx <-. val_ (Just 0))
                                     (\tx -> _tx_block tx ==. val_ (BlockId (hashToDbHash $ _blockHeader_hash header)))
                             logg Debug $ fromString $ show e
-                        else logg Error $ fromString $ printf "[FAIL] no payloads for header range (%d, %d) on chain %d" (coerce chunkLow :: Int) (coerce chunkHigh :: Int) chain
+                        else logg Error $ fromString $ printf "no payloads for header range (%d, %d) on chain %d" (coerce chunkLow :: Int) (coerce chunkHigh :: Int) chain
                     Right bpwos -> do
-                      let writePayload current_header bpwo = do
-                            let mh = find (\header -> _blockHeader_hash header == _blockHeader_hash current_header) headers
-                            case mh of
-                              Nothing -> pure ()
-                              Just header -> do
-                                let allTxsEvents = snd $ mkBlockEvents' (fromIntegral h) (ChainId $ fromIntegral chain) current_hash bpwo
-                                    current_hash = hashToDbHash $ _blockHeader_hash current_header
-                                    h = _blockHeader_height header
-                                    rqKeyEventsMap = allTxsEvents
-                                      & mapMaybe (\ev -> fmap (flip (,) 1) (_ev_requestkey ev))
-                                      & M.fromListWith (+)
-
-                                P.withResource pool $ \c ->
-                                  withTransaction c $ do
-                                    runBeamPostgres c $
-                                      runInsert
-                                        $ insert (_cddb_events database) (insertValues $ fst $ mkBlockEvents' (fromIntegral h) (ChainId $ fromIntegral chain) current_hash bpwo)
-                                        $ onConflict (conflictingFields primaryKey) onConflictDoNothing
-                                    withSavepoint c $ runBeamPostgres c $
-                                      iforM_ rqKeyEventsMap $ \reqKey num_events ->
-                                        runUpdate
-                                          $ update (_cddb_transactions database)
-                                            (\tx -> _tx_numEvents tx <-. val_ (Just num_events))
-                                            (\tx -> _tx_requestKey tx ==. val_ (unDbHash reqKey))
-                                atomicModifyIORef' counter (\n -> (n+1, ()))
-                      forM_ bpwos (uncurry writePayload)
+                      let write header bpwo = do
+                            let curHash = hashToDbHash $ _blockHeader_hash header
+                                height = fromIntegral $ _blockHeader_height header
+                            writePayload pool (ChainId $ fromIntegral chain) curHash height bpwo
+                            atomicModifyIORef' counter (\n -> (n+1, ()))
+                      forM_ bpwos (uncurry write)
               forM_ delay threadDelay
 
   where
     logg = _env_logger env
     delay = _backfillArgs_delayMicros args
     pool = _env_dbConnPool env
+    allCids = _env_chainsAtHeight env
 
 getCoinbaseGaps :: Env -> Int64 -> IO [(Int64, Int64, Int64)]
-getCoinbaseGaps env startingHeight = P.withResource (_env_dbConnPool env) $ \c -> runBeamPostgresDebug (_env_logger env Debug . fromString) c $ do
-  gaps <- runSelectReturningList $ selectWith $ do
-    gaps <- selecting $
-      withWindow_ (\e -> frame_ (partitionBy_ (_ev_chainid e)) (orderPartitionBy_ $ asc_ $ _ev_height e) noBounds_)
-                  (\e w -> (_ev_chainid e, _ev_height e, lead_ (_ev_height e) (val_ (1 :: Int64)) `over_` w))
-                  (all_ $ _cddb_events database)
-    pure $ orderBy_ (\(cid,a,_) -> (desc_ a, asc_ cid)) $ do
-      res@(_,a,b) <- reuse gaps
-      guard_ ((b - a) >. val_ 1)
-      pure res
-  minHeights <- runSelectReturningList $ select $ aggregate_ (\e -> (group_ (_ev_chainid e), min_ (_ev_height e))) (all_ (_cddb_events database))
-  let addStart [] = gaps
-      addStart ((_,Nothing):ms) = addStart ms
-      addStart ((cid,Just m):ms) = if m > startingHeight
-                                     then (cid, startingHeight, m) : addStart ms
-                                     else addStart ms
-  pure $ addStart minHeights
+getCoinbaseGaps env startingHeight = withDbDebug env Debug $ do
+    gaps <- runSelectReturningList $ selectWith $ do
+      gaps <- selecting $
+        withWindow_ (\e -> frame_ (partitionBy_ (_ev_chainid e)) (orderPartitionBy_ $ asc_ $ _ev_height e) noBounds_)
+                    (\e w -> (_ev_chainid e, _ev_height e, lead_ (_ev_height e) (val_ (1 :: Int64)) `over_` w))
+                    (all_ $ _cddb_events database)
+      pure $ orderBy_ (\(cid,a,_) -> (desc_ a, asc_ cid)) $ do
+        res@(_,a,b) <- reuse gaps
+        guard_ ((b - a) >. val_ 1)
+        pure res
+    minHeights <- chainMinHeights
+    liftIO $ logg Debug $ fromString $ "minHeights: " <> show minHeights
+    let addStart [] = gaps
+        addStart ((_,Nothing):ms) = addStart ms
+        addStart ((cid,Just m):ms) = if m > startingHeight
+                                       then (cid, startingHeight, m) : addStart ms
+                                       else addStart ms
+    pure $ addStart minHeights
+  where
+    logg = _env_logger env
+
+chainMinHeights :: Pg [(Int64, Maybe Int64)]
+chainMinHeights = runSelectReturningList $ select $ aggregate_ (\e -> (group_ (_ev_chainid e), min_ (_ev_height e))) (all_ (_cddb_events database))
 
 --with gaps as (select chainid, height, LEAD (height,1) OVER (PARTITION BY chainid ORDER BY height ASC) AS next_height from events) select * from gaps where next_height - height > 1;
 

--- a/exec/Chainweb/Gaps.hs
+++ b/exec/Chainweb/Gaps.hs
@@ -61,7 +61,7 @@ gapsCut env delay cutBS = do
                     Just _ -> Seq
           total = length bs
       logg Info $ fromString $ printf "[INFO] Filling %d gaps\n" total
-      race_ (progress count total) $
+      race_ (progress logg count total) $
         traverseConcurrently_ strat (f logg count) bs
       final <- readIORef count
       logg Info $ fromString $ printf "[INFO] Filled in %d missing blocks.\n" final

--- a/exec/Chainweb/Lookups.hs
+++ b/exec/Chainweb/Lookups.hs
@@ -193,20 +193,25 @@ mkBlockTransactions b pl = map (mkTransaction b) $ _blockPayloadWithOutputs_tran
 -- the current block hash and NOT the parent hash However, the source key of the
 -- event in chainweb-data database instance is the current block hash and NOT
 -- the parent hash.
-mkBlockEvents' :: Int64 -> ChainId -> DbHash BlockHash -> BlockPayloadWithOutputs -> ([Event], [Event])
-mkBlockEvents' height cid blockhash pl = _blockPayloadWithOutputs_transactionsWithOutputs pl
-    & concatMap (mkTxEvents height cid)
-    & ((,) (mkCoinbaseEvents height cid blockhash pl))
+mkBlockEvents' :: Int64 -> ChainId -> DbHash BlockHash -> BlockPayloadWithOutputs -> ([Event], [(DbHash TxHash, [Event])])
+mkBlockEvents' height cid blockhash pl =
+    (mkCoinbaseEvents height cid blockhash pl, map mkPair tos)
+  where
+    tos = _blockPayloadWithOutputs_transactionsWithOutputs pl
+    mkPair p = ( DbHash $ hashB64U $ CW._transaction_hash $ fst p
+               , mkTxEvents height cid blockhash p)
 
 mkBlockEvents :: Int64 -> ChainId -> DbHash BlockHash -> BlockPayloadWithOutputs -> [Event]
-mkBlockEvents height cid blockhash pl = uncurry (++) (mkBlockEvents' height cid blockhash pl)
+mkBlockEvents height cid blockhash pl =  cbes ++ concatMap snd txes
+  where
+    (cbes, txes) = mkBlockEvents' height cid blockhash pl
 
 mkCoinbaseEvents :: Int64 -> ChainId -> DbHash BlockHash -> BlockPayloadWithOutputs -> [Event]
 mkCoinbaseEvents height cid blockhash pl = _blockPayloadWithOutputs_coinbase pl
     & coerce
     & _toutEvents
     {- idx of coinbase transactions is set to 0.... this value is just a placeholder-}
-    <&> \ev -> mkEvent cid height (Right blockhash) ev 0
+    <&> \ev -> mkEvent cid height blockhash Nothing ev 0
 
 bpwoMinerKeys :: BlockPayloadWithOutputs -> [T.Text]
 bpwoMinerKeys = _minerData_publicKeys . _blockPayloadWithOutputs_minerData
@@ -221,7 +226,7 @@ mkTransaction b (tx,txo) = Transaction
   , _tx_gasPrice = _chainwebMeta_gasPrice mta
   , _tx_sender = _chainwebMeta_sender mta
   , _tx_nonce = _pactCommand_nonce cmd
-  , _tx_requestKey = hashB64U $ CW._transaction_hash tx
+  , _tx_requestKey = DbHash $ hashB64U $ CW._transaction_hash tx
   , _tx_code = _exec_code <$> exc
   , _tx_pactId = _cont_pactId <$> cnt
   , _tx_rollback = _cont_rollback <$> cnt
@@ -253,13 +258,14 @@ mkTransaction b (tx,txo) = Transaction
       PactResult (Left v) -> (Just $ PgJSONB v, Nothing)
       PactResult (Right v) -> (Nothing, Just $ PgJSONB v)
 
-mkTxEvents :: Int64 -> ChainId -> (CW.Transaction,TransactionOutput) -> [Event]
-mkTxEvents height cid (tx,txo) = zipWith (mkEvent cid height (Left k)) (_toutEvents txo) [0..]
+mkTxEvents :: Int64 -> ChainId -> DbHash BlockHash -> (CW.Transaction,TransactionOutput) -> [Event]
+mkTxEvents height cid blk (tx,txo) = zipWith (mkEvent cid height blk (Just rk)) (_toutEvents txo) [0..]
   where
-    k = DbHash $ hashB64U $ CW._transaction_hash tx
+    rk = DbHash $ hashB64U $ CW._transaction_hash tx
+    
 
-mkEvent :: ChainId -> Int64 -> Either (DbHash PayloadHash) (DbHash BlockHash) -> Value -> Int64 -> Event
-mkEvent (ChainId chainid) height requestkeyOrBlock ev idx = Event
+mkEvent :: ChainId -> Int64 -> DbHash BlockHash -> Maybe (DbHash TxHash) -> Value -> Int64 -> Event
+mkEvent (ChainId chainid) height block requestkey ev idx = Event
     { _ev_requestkey = requestkey
     , _ev_block = block
     , _ev_chainid = fromIntegral chainid
@@ -273,8 +279,6 @@ mkEvent (ChainId chainid) height requestkeyOrBlock ev idx = Event
     , _ev_params = PgJSONB $ toList $ params ev
     }
   where
-    requestkey = either Just (const Nothing) requestkeyOrBlock
-    block = either (const Nothing) Just requestkeyOrBlock
     ename = fromMaybe "" . str "name"
     emodule = fromMaybe "" . join . fmap qualm . lkp "module"
     qname ev' = case join $ fmap qualm $ lkp "module" ev' of

--- a/exec/Chainweb/Server.hs
+++ b/exec/Chainweb/Server.hs
@@ -147,7 +147,7 @@ apiServerCut env senv cutBS = do
   numTxs <- getTransactionCount logg pool
   ssRef <- newIORef $ ServerState recentTxs 0 numTxs (hush circulatingCoins)
   logg Info $ fromString $ "Total number of transactions: " <> show numTxs
-  _ <- forkIO $ scheduledUpdates env senv pool ssRef
+  _ <- forkIO $ scheduledUpdates env pool ssRef
   _ <- forkIO $ listenWithHandler env $ serverHeaderHandler env pool ssRef
   logg Info $ fromString "Starting chainweb-data server"
   let serverApp req =
@@ -165,11 +165,10 @@ apiServerCut env senv cutBS = do
 
 scheduledUpdates
   :: Env
-  -> ServerEnv
   -> P.Pool Connection
   -> IORef ServerState
   -> IO ()
-scheduledUpdates env senv pool ssRef = forever $ do
+scheduledUpdates env pool ssRef = forever $ do
     threadDelay (60 * 60 * 24 * micros)
 
     now <- getCurrentTime

--- a/exec/Chainweb/Worker.hs
+++ b/exec/Chainweb/Worker.hs
@@ -43,13 +43,13 @@ import           System.Logger hiding (logg)
 writes :: P.Pool Connection -> Block -> [T.Text] -> [Transaction] -> [Event] -> IO ()
 writes pool b ks ts es = P.withResource pool $ \c -> withTransaction c $ do
      runBeamPostgres c $ do
-        -- Write Pub Key many-to-many relationships if unique --
-        runInsert
-          $ insert (_cddb_minerkeys database) (insertValues $ map (MinerKey (pk b)) ks)
-          $ onConflict (conflictingFields primaryKey) onConflictDoNothing
         -- Write the Block if unique --
         runInsert
           $ insert (_cddb_blocks database) (insertValues [b])
+          $ onConflict (conflictingFields primaryKey) onConflictDoNothing
+        -- Write Pub Key many-to-many relationships if unique --
+        runInsert
+          $ insert (_cddb_minerkeys database) (insertValues $ map (MinerKey (pk b)) ks)
           $ onConflict (conflictingFields primaryKey) onConflictDoNothing
      {- We should still be able to write the block & miner keys data if writing
      either the transaction or event data somehow fails. -}

--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -9,11 +9,12 @@ import           Chainweb.Api.NodeInfo
 import           Chainweb.Backfill (backfill)
 import           Chainweb.Database (initializeTables)
 import           Chainweb.Env
+import           Chainweb.FillEvents (fillEvents)
 import           Chainweb.Gaps (gaps)
 import           Chainweb.Listen (listen)
-import           Chainweb.Server (apiServer)
 import           Chainweb.Lookups (getNodeInfo)
 import           Chainweb.RichList (richList)
+import           Chainweb.Server (apiServer)
 import           Chainweb.Single (single)
 import           Data.Bifunctor
 import qualified Data.Pool as P
@@ -65,6 +66,7 @@ main = do
                   Backfill as -> backfill env as
                   Gaps rateLimit -> gaps env rateLimit
                   Single cid h -> single env cid h
+                  FillEvents as et -> fillEvents env as et
                   Server serverEnv -> apiServer env serverEnv
   where
     opts = info ((richListP <|> envP) <**> helper)

--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -51,12 +51,12 @@ main = do
               logg Info $ "[INFO] Constructing rich list using given db-path: " <> fromString fp
               return fp
           richList logg fp
-        Args c pgc us u _ -> do
+        Args c pgc us u _ ms -> do
           logg Info $ "Using database: " <> fromString (show pgc)
           logg Info $ "Service API: " <> fromString (showUrlScheme us)
           logg Info $ "P2P API: " <> fromString (showUrlScheme (UrlScheme Https u))
           withPool pgc $ \pool -> do
-            P.withResource pool (initializeTables logg)
+            P.withResource pool (initializeTables logg ms)
             logg Info "DB Tables Initialized"
             let mgrSettings = mkManagerSettings (TLSSettingsSimple True False False) Nothing
             m <- newManager mgrSettings
@@ -82,7 +82,7 @@ main = do
       & loggerConfigThreshold .~ level
     backendConfig = defaultHandleBackendConfig
     getLevel = \case
-      Args _ _ _ _ level -> level
+      Args _ _ _ _ level _ -> level
       RichListArgs _ level -> level
 
 

--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -73,6 +73,7 @@ main = do
                       Backfill as -> backfill env as
                       Gaps rateLimit -> gaps env rateLimit
                       Single cid h -> single env cid h
+                      FillEvents as et -> fillEvents env as et
                       Server serverEnv -> apiServer env serverEnv
   where
     opts = info ((richListP <|> envP) <**> helper)

--- a/lib/ChainwebData/Types.hs
+++ b/lib/ChainwebData/Types.hs
@@ -14,6 +14,7 @@ module ChainwebData.Types
 
     -- * Utils
   , groupsOf
+  , rangeToDescGroupsOf
   ) where
 
 import           BasePrelude
@@ -83,6 +84,16 @@ newtype Low = Low Int
 
 newtype High = High Int
   deriving newtype (Eq, Ord, Show, Num)
+
+-- | Divides a range [low,high] (inclusive) into a list of ranges with at most
+-- n elements.  The returned list of ranges is ordered descending with the
+-- highest range at the front.
+rangeToDescGroupsOf :: Int -> Low -> High -> [(Low, High)]
+rangeToDescGroupsOf n l@(Low low) h@(High high)
+  | high - low <= n = [(l, High high)]
+  | otherwise =
+    let nextHigh = high - n
+     in (Low $ nextHigh + 1, h) : rangeToDescGroupsOf n l (High nextHigh)
 
 --------------------------------------------------------------------------------
 -- Orphans

--- a/lib/ChainwebDb/Types/Block.hs
+++ b/lib/ChainwebDb/Types/Block.hs
@@ -21,8 +21,9 @@ import Data.Scientific
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
 import Database.Beam
+import Database.Beam.AutoMigrate hiding (Table)
+import Database.Beam.Backend.SQL hiding (tableName)
 import Database.Beam.Backend.SQL.Row (FromBackendRow)
-import Database.Beam.Backend.SQL.SQL92
 import Database.Beam.Migrate
 import Database.Beam.Postgres (Postgres)
 import Database.Beam.Postgres.Syntax (PgValueSyntax)
@@ -40,6 +41,10 @@ newtype HashAsNum = HashAsNum { unHashAsNum :: Scientific }
 
 instance BeamMigrateSqlBackend be => HasDefaultSqlDataType be HashAsNum where
   defaultSqlDataType _ _ _ = numericType (Just (80, Nothing))
+
+instance HasColumnType HashAsNum where
+  defaultColumnType _ = SqlStdType $ numericType (Just (80, Nothing))
+  defaultTypeCast _ = Just "numeric"
 
 ------------------------------------------------------------------------------
 data BlockT f = Block

--- a/lib/ChainwebDb/Types/DbHash.hs
+++ b/lib/ChainwebDb/Types/DbHash.hs
@@ -8,6 +8,8 @@ module ChainwebDb.Types.DbHash where
 ------------------------------------------------------------------------------
 import Data.Aeson
 import Data.Text (Text)
+import Database.Beam.AutoMigrate
+import Database.Beam.Backend.SQL hiding (tableName)
 import Database.Beam.Backend.SQL.Row (FromBackendRow)
 import Database.Beam.Backend.SQL.SQL92 (HasSqlValueSyntax)
 import Database.Beam.Migrate (HasDefaultSqlDataType)
@@ -34,3 +36,8 @@ instance ToJSON (DbHash t) where
 
 instance FromJSON (DbHash t) where
     parseJSON = withText "DbHash" $ \v -> pure $ DbHash v
+
+instance HasColumnType (DbHash a) where
+  defaultColumnType _ = SqlStdType $ varCharType Nothing Nothing
+  defaultTypeCast _ = Just "character varying"
+

--- a/lib/ChainwebDb/Types/DbHash.hs
+++ b/lib/ChainwebDb/Types/DbHash.hs
@@ -21,6 +21,7 @@ import GHC.Generics
 data PayloadHash = PayloadHash
 data PowHash = PowHash
 data BlockHash = BlockHash
+data TxHash = TxHash -- i.e. requestkey
 
 -- | DB hashes stored as Base64Url encoded text for more convenient querying.
 newtype DbHash t = DbHash { unDbHash :: Text }

--- a/lib/ChainwebDb/Types/Event.hs
+++ b/lib/ChainwebDb/Types/Event.hs
@@ -24,8 +24,8 @@ import Database.Beam.Postgres (PgJSONB)
 import ChainwebDb.Types.DbHash
 ------------------------------------------------------------------------------
 data EventT f = Event
-  { _ev_requestkey :: C f (Maybe (DbHash PayloadHash))
-  , _ev_block :: C f (Maybe (DbHash BlockHash))
+  { _ev_requestkey :: C f (Maybe (DbHash TxHash))
+  , _ev_block :: C f (DbHash BlockHash)
   , _ev_chainid :: C f Int64
   , _ev_height :: C f Int64
   , _ev_idx :: C f Int64
@@ -57,7 +57,7 @@ type Event = EventT Identity
 type EventId = PrimaryKey EventT Identity
 
 instance Table EventT where
-  data PrimaryKey EventT f = EventId (C f Int64) (C f Int64) (C f Int64)
+  data PrimaryKey EventT f = EventNoId
     deriving stock (Generic)
     deriving anyclass (Beamable)
 {-
@@ -72,4 +72,4 @@ chainweb-data: internal error: Unable to commit 1048576 bytes of memory
     Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug
 Killed
 -}
-  primaryKey = EventId <$> _ev_chainid <*> _ev_height <*> _ev_idx
+  primaryKey _ = EventNoId

--- a/lib/ChainwebDb/Types/Transaction.hs
+++ b/lib/ChainwebDb/Types/Transaction.hs
@@ -23,6 +23,7 @@ import Database.Beam
 import Database.Beam.Postgres (PgJSONB)
 ------------------------------------------------------------------------------
 import ChainwebDb.Types.Block
+import ChainwebDb.Types.DbHash
 ------------------------------------------------------------------------------
 
 
@@ -36,7 +37,7 @@ data TransactionT f = Transaction
   , _tx_gasPrice :: C f Double
   , _tx_sender :: C f Text
   , _tx_nonce :: C f Text
-  , _tx_requestKey :: C f Text
+  , _tx_requestKey :: C f (DbHash TxHash)
   , _tx_code :: C f (Maybe Text)
   , _tx_pactId :: C f (Maybe Text)
   , _tx_rollback :: C f (Maybe Bool)
@@ -96,7 +97,7 @@ type TransactionId = PrimaryKey TransactionT Identity
 -- deriving instance Ord (PrimaryKey TransactionT Maybe)
 
 instance Table TransactionT where
-  data PrimaryKey TransactionT f = TransactionId (C f Text) (PrimaryKey BlockT f)
+  data PrimaryKey TransactionT f = TransactionId (C f (DbHash TxHash)) (PrimaryKey BlockT f)
     deriving stock (Generic)
     deriving anyclass (Beamable)
   primaryKey tx = TransactionId (_tx_requestKey tx) (_tx_block tx)

--- a/migrations.md
+++ b/migrations.md
@@ -15,27 +15,20 @@ ALTER COLUMN step SET DATA TYPE bigint,
 ALTER COLUMN gas SET DATA TYPE bigint,
 ALTER COLUMN txid SET DATA TYPE bigint;
 ```
-# 2021-06-25 Events schema change
 
+# 2021-07-29 1.3.0 Schema migration
 
-```
-ALTER TABLE transactions
-ADD COLUMN num_events SET DATA TYPE bigint;
-
-ALTER TABLE events
-RENAME COLUMN requestkey TO sourcekey,
-ADD COLUMN sourcetype SET DATA TYPE VARCHAR SET NOT NULL,
-DROP CONSTRAINT events_pkey,
-ADD PRIMARY KEY (sourcekey, idx);
-
-UPDATE events SET sourcetype = 'Source_Tx';
-```
-
-# 2021-07-16 Expand transactions primary key
+* Add `num_events` to transactions table
+* Expand transactions primary key
 
 ```
 BEGIN;
+ALTER TABLE transactions ADD COLUMN num_events SET DATA TYPE bigint;
 ALTER TABLE transactions DROP CONSTRAINT transactions_pkey;
 ALTER TABLE transactions ADD PRIMARY KEY (requestkey, block);
 COMMIT;
 ```
+
+* A new `events` table is also being added but that component of the migration
+  will be performed automatically if you run with `-m`.
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -33,5 +33,6 @@ extra-deps:
       - gargoyle
       - gargoyle-postgresql
       - gargoyle-postgresql-connect
+      - gargoyle-postgresql-nix
   - git: https://github.com/kadena-io/thyme.git
     commit: 6ee9fcb026ebdb49b810802a981d166680d867c9

--- a/stack.yaml
+++ b/stack.yaml
@@ -25,6 +25,8 @@ extra-deps:
       - beam-core
       - beam-migrate
       - beam-postgres
+  - github: mightybyte/beam-automigrate
+    commit: 0fd33d660a523941ad78bcd9869a6e3d9220008e
   - github: obsidiansystems/gargoyle
     commit: b0bf855cc91f7cc3b986083af8fbc9da59c86b56
     subdirs:

--- a/stack.yaml
+++ b/stack.yaml
@@ -32,7 +32,5 @@ extra-deps:
     subdirs:
       - gargoyle
       - gargoyle-postgresql
-      - gargoyle-postgresql-connect
-      - gargoyle-postgresql-nix
   - git: https://github.com/kadena-io/thyme.git
     commit: 6ee9fcb026ebdb49b810802a981d166680d867c9

--- a/stack.yaml
+++ b/stack.yaml
@@ -26,7 +26,7 @@ extra-deps:
       - beam-migrate
       - beam-postgres
   - github: mightybyte/beam-automigrate
-    commit: 0fd33d660a523941ad78bcd9869a6e3d9220008e
+    commit: 112c39953c432b05ec6ae2354b0150c61ee30157
   - github: obsidiansystems/gargoyle
     commit: b0bf855cc91f7cc3b986083af8fbc9da59c86b56
     subdirs:

--- a/stack.yaml
+++ b/stack.yaml
@@ -32,5 +32,6 @@ extra-deps:
     subdirs:
       - gargoyle
       - gargoyle-postgresql
+      - gargoyle-postgresql-connect
   - git: https://github.com/kadena-io/thyme.git
     commit: 6ee9fcb026ebdb49b810802a981d166680d867c9


### PR DESCRIPTION
The existing `gaps` command does not fill gaps in the event table because it searches for gaps in the block table.  This PR creates a new standalone command for filling events that looks for gaps in the events table itself.