### PR TITLE
Bump chainweb-api to ditch the base64 padding

### DIFF
--- a/deps/chainweb-api/github.json
+++ b/deps/chainweb-api/github.json
@@ -3,6 +3,6 @@
   "repo": "chainweb-api",
   "branch": "master",
   "private": false,
-  "rev": "fc85edb708853ff08be1c0ca8652de6aa8b9367c",
-  "sha256": "1iw5zix03azfr98xfb0slv9blsmhpg4s44d3f6zbhl2dqmr59bxl"
+  "rev": "aafdcfa8c6c870e3adef868d9ea615bd773b1dd9",
+  "sha256": "0431f6s3z8dawlsaq14bdsyn7xm73blyjidc6vih518zpcrl4j5h"
 }


### PR DESCRIPTION
This will change request keys and other base64-encoded hashes in the DB to not have a trailing equals sign.  This will allow more accurate matching and joining between tables to places where the hashes do not have any padding.