### PR TITLE
Accounts Handler Shim

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: 4d3d0ac5108254ac27408101903ee503702873ba
+    tag: 4e8e820d4888a5a29087b97798f0d6551593ff33
 
 source-repository-package
     type: git

--- a/exec/Chainweb/Server.hs
+++ b/exec/Chainweb/Server.hs
@@ -422,7 +422,7 @@ accountHandler
   -> Maybe Limit
   -> Maybe Offset
   -> Handler [AccountDetail]
-accountHandler _logger _pool _token _accountName _chain _limit _offset = throw404 "accounts endpoint has yet to implemented"
+accountHandler _logger _pool _token _accountName _chain _limit _offset = throw404 "accounts endpoint has yet to be implemented"
 
 evHandler
   :: LogFunctionIO Text

--- a/exec/Chainweb/Server.hs
+++ b/exec/Chainweb/Server.hs
@@ -67,6 +67,7 @@ import           Chainweb.Lookups
 import           Chainweb.RichList
 import           ChainwebData.Types
 import           ChainwebData.Api
+import           ChainwebData.AccountDetail
 import           ChainwebData.EventDetail
 import           ChainwebData.Pagination
 import           ChainwebData.TxDetail
@@ -162,6 +163,7 @@ apiServerCut env senv cutBS = do
             :<|> evHandler logg pool req
             :<|> txHandler logg pool
             :<|> txsHandler logg pool
+            :<|> accountHandler logg pool
           )
             :<|> statsHandler ssRef
             :<|> coinsHandler ssRef
@@ -410,6 +412,17 @@ txsHandler logger pool (Just (RequestKey rk)) =
     unMaybeValue = maybe Null unPgJsonb
     toTxEvent ev =
       TxEvent (_ev_qualName ev) (unPgJsonb $ _ev_params ev)
+
+accountHandler
+  :: LogFunctionIO Text
+  -> P.Pool Connection
+  -> Text
+  -> Text
+  -> Int
+  -> Maybe Limit
+  -> Maybe Offset
+  -> Handler [AccountDetail]
+accountHandler _logger _pool _token _accountName _chain _limit _offset = throw404 "accounts endpoint has yet to implemented"
 
 evHandler
   :: LogFunctionIO Text


### PR DESCRIPTION
We need this in place because chainweb-api has been updated on master to
include the accounts endpoint api that chainweb-data depends upon. If
someone were to try to query for some account details, they would get
back a 404 message.