### PR TITLE
Change numeric type of transfer amount type to Decimal

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: 4e8e820d4888a5a29087b97798f0d6551593ff33
+    tag: b7fdbe35dbe4e7b818dc9650fdb950ea5eb7990f
 
 source-repository-package
     type: git

--- a/deps/chainweb-api/github.json
+++ b/deps/chainweb-api/github.json
@@ -3,6 +3,6 @@
   "repo": "chainweb-api",
   "branch": "master",
   "private": false,
-  "rev": "27d45461841ec0c8527c3b8854b2eeda405607a0",
+  "rev": "b7fdbe35dbe4e7b818dc9650fdb950ea5eb7990f",
   "sha256": "0vcjrj6nfad4sf06rl5z20pjsvagh1r77ljjm2hpcfryq7hkwp31"
 }

--- a/exec/Chainweb/BackfillTransfers.hs
+++ b/exec/Chainweb/BackfillTransfers.hs
@@ -25,10 +25,8 @@ import           Control.Lens hiding ((<.), reuse)
 
 import qualified Data.Aeson as A
 import           Data.Aeson.Lens
-import           Data.Decimal
 import qualified Data.Pool as P
 import qualified Data.Text.Read as TR
-import           Data.Scientific
 
 import           Database.Beam hiding (insert)
 import           Database.Beam.Postgres
@@ -122,23 +120,20 @@ createTransfer ev = do
       [_,_,_] -> True
       _ -> False
 
-getAmount :: [A.Value] -> Maybe KDADecimal
-getAmount params = fmap KDADecimal $
+getAmount :: [A.Value] -> Maybe KDAScientific
+getAmount params = fmap KDAScientific $
     (params ^? ix 2 . key "decimal" . _String . to TR.rational  . _Right . _1)
     <|>
     (params ^? ix 2 . key "int" . _String . to TR.rational . _Right . _1)
     <|>
-    (params ^? ix 2 . _Number . to f)
+    (params ^? ix 2 . _Number)
     <|>
     -- These cases shouldn't be ever reached but these are here just in case
-    (params ^? ix 2 . key "int" . _Number . to f)
+    (params ^? ix 2 . key "int" . _Number)
     <|>
-    (params ^? ix 2 . key "decimal" . _Number . to f)
+    (params ^? ix 2 . key "decimal" . _Number)
     <|>
     (params ^? ix 2 . _String . to TR.rational . _Right . _1)
-  where
-    f :: Scientific -> Decimal
-    f = undefined
 
 eventSelector' :: Int64 -> Int64 -> Q Postgres ChainwebDataDb s (EventT (QExpr Postgres s))
 eventSelector' startingHeight endingHeight = do

--- a/exec/Chainweb/BackfillTransfers.hs
+++ b/exec/Chainweb/BackfillTransfers.hs
@@ -25,8 +25,10 @@ import           Control.Lens hiding ((<.), reuse)
 
 import qualified Data.Aeson as A
 import           Data.Aeson.Lens
+import           Data.Decimal
 import qualified Data.Pool as P
 import qualified Data.Text.Read as TR
+import           Data.Scientific
 
 import           Database.Beam hiding (insert)
 import           Database.Beam.Postgres
@@ -120,20 +122,23 @@ createTransfer ev = do
       [_,_,_] -> True
       _ -> False
 
-getAmount :: [A.Value] -> Maybe KDAScientific
-getAmount params = fmap KDAScientific $
+getAmount :: [A.Value] -> Maybe KDADecimal
+getAmount params = fmap KDADecimal $
     (params ^? ix 2 . key "decimal" . _String . to TR.rational  . _Right . _1)
     <|>
     (params ^? ix 2 . key "int" . _String . to TR.rational . _Right . _1)
     <|>
-    (params ^? ix 2 . _Number)
+    (params ^? ix 2 . _Number . to f)
     <|>
     -- These cases shouldn't be ever reached but these are here just in case
-    (params ^? ix 2 . key "int" . _Number)
+    (params ^? ix 2 . key "int" . _Number . to f)
     <|>
-    (params ^? ix 2 . key "decimal" . _Number)
+    (params ^? ix 2 . key "decimal" . _Number . to f)
     <|>
     (params ^? ix 2 . _String . to TR.rational . _Right . _1)
+  where
+    f :: Scientific -> Decimal
+    f = undefined
 
 eventSelector' :: Int64 -> Int64 -> Q Postgres ChainwebDataDb s (EventT (QExpr Postgres s))
 eventSelector' startingHeight endingHeight = do

--- a/lib/ChainwebDb/Types/Transfer.hs
+++ b/lib/ChainwebDb/Types/Transfer.hs
@@ -17,10 +17,9 @@ module ChainwebDb.Types.Transfer where
 
 ----------------------------------------------------------------------------
 import BasePrelude
-import Data.Decimal
+import Data.Scientific
 import Data.Text (Text)
 import Database.Beam
-import Database.Beam.AutoMigrate.Types hiding (Table)
 import Database.Beam.Backend.SQL.SQL92
 import Database.Beam.Postgres
 import Database.Beam.Postgres.Syntax
@@ -41,7 +40,7 @@ data TransferT f = Transfer
   , _tr_moduleHash :: C f Text
   , _tr_from_acct :: C f Text
   , _tr_to_acct :: C f Text
-  , _tr_amount :: C f KDADecimal
+  , _tr_amount :: C f KDAScientific
   }
   deriving stock (Generic)
   deriving anyclass (Beamable)
@@ -81,30 +80,5 @@ precision and scale of the newtype KDAScientific.
 
 -}
 
-newtype KDADecimal = KDADecimal { getKDADecimal :: Decimal }
-  deriving Eq
-
-instance Show KDADecimal where
-  show (KDADecimal d) = show d
-
-instance BA.HasColumnType KDADecimal where
-  -- defaultColumnType _ = SqlStdType $ numericType (Just (21, Just 12))
-  defaultColumnType _ = SqlStdType $ numericType Nothing
-  defaultTypeCast _ = Just "numeric"
-
-instance HasSqlValueSyntax PgValueSyntax KDADecimal where
-  sqlValueSyntax = defaultPgValueSyntax
-
-instance ToField KDADecimal where
-  toField (KDADecimal s) = toField s
-
-instance ToField Decimal where
-  toField = undefined
-
-instance FromField Decimal where
-  fromField = undefined
-
-instance FromBackendRow Postgres KDADecimal where
-
-instance FromField KDADecimal where
-  fromField f mb = fmap KDADecimal $ fromField f mb
+newtype KDAScientific = KDAScientific { getKDAScientific :: Scientific }
+  deriving newtype (Eq, Show, BA.HasColumnType, HasSqlValueSyntax PgValueSyntax, ToField, FromField, FromBackendRow Postgres)

--- a/lib/ChainwebDb/Types/Transfer.hs
+++ b/lib/ChainwebDb/Types/Transfer.hs
@@ -17,7 +17,7 @@ module ChainwebDb.Types.Transfer where
 
 ----------------------------------------------------------------------------
 import BasePrelude
-import Data.Scientific
+import Data.Decimal
 import Data.Text (Text)
 import Database.Beam
 import Database.Beam.AutoMigrate.Types hiding (Table)
@@ -41,7 +41,7 @@ data TransferT f = Transfer
   , _tr_moduleHash :: C f Text
   , _tr_from_acct :: C f Text
   , _tr_to_acct :: C f Text
-  , _tr_amount :: C f KDAScientific
+  , _tr_amount :: C f KDADecimal
   }
   deriving stock (Generic)
   deriving anyclass (Beamable)
@@ -81,24 +81,30 @@ precision and scale of the newtype KDAScientific.
 
 -}
 
-newtype KDAScientific = KDAScientific { getKDAScientific :: Scientific }
+newtype KDADecimal = KDADecimal { getKDADecimal :: Decimal }
   deriving Eq
 
-instance Show KDAScientific where
-  show (KDAScientific s) = show s
+instance Show KDADecimal where
+  show (KDADecimal d) = show d
 
-instance BA.HasColumnType KDAScientific where
+instance BA.HasColumnType KDADecimal where
   -- defaultColumnType _ = SqlStdType $ numericType (Just (21, Just 12))
   defaultColumnType _ = SqlStdType $ numericType Nothing
   defaultTypeCast _ = Just "numeric"
 
-instance HasSqlValueSyntax PgValueSyntax KDAScientific where
+instance HasSqlValueSyntax PgValueSyntax KDADecimal where
   sqlValueSyntax = defaultPgValueSyntax
 
-instance ToField KDAScientific where
-  toField (KDAScientific s) = toField s
+instance ToField KDADecimal where
+  toField (KDADecimal s) = toField s
 
-instance FromBackendRow Postgres KDAScientific where
+instance ToField Decimal where
+  toField = undefined
 
-instance FromField KDAScientific where
-  fromField f mb = fmap KDAScientific $ fromField f mb
+instance FromField Decimal where
+  fromField = undefined
+
+instance FromBackendRow Postgres KDADecimal where
+
+instance FromField KDADecimal where
+  fromField f mb = fmap KDADecimal $ fromField f mb

--- a/lib/ChainwebDb/Types/Transfer.hs
+++ b/lib/ChainwebDb/Types/Transfer.hs
@@ -67,18 +67,9 @@ instance Table TransferT where
     deriving anyclass (Beamable)
   primaryKey = TransferId <$> _tr_block <*> _tr_requestkey <*> _tr_chainid <*> _tr_idx <*> _tr_moduleHash
 
-{-
-
-The two values in given to the function numericType correspond to the precision
-and scale of the numeric type. Read here for more information
-https://www.postgresql.org/docs/current/datatype-numeric.html.
-
-Since the maximum amount of kda someone can have in their posssession is around
-1 billion and also the maximum precision of any number represented by pact needs
-12 digits past the decimal point, we have chosen the numbers 21 and 12 for the
-precision and scale of the newtype KDAScientific.
-
--}
-
 newtype KDAScientific = KDAScientific { getKDAScientific :: Scientific }
-  deriving newtype (Eq, Show, BA.HasColumnType, HasSqlValueSyntax PgValueSyntax, ToField, FromField, FromBackendRow Postgres)
+  deriving newtype (Eq, Show, HasSqlValueSyntax PgValueSyntax, ToField, FromField, FromBackendRow Postgres)
+
+instance BA.HasColumnType KDAScientific where
+  defaultColumnType _ = BA.SqlStdType (numericType Nothing)
+  defaultTypeCast _ = Just "numeric"


### PR DESCRIPTION
We concluded that Decimal is the best way to go given these considerations:

1. We could store the  amount as json, especially considering that the corresponding events sometimes stores the amount as json. 

Pro(s) - We don't have to think very hard about how to represent the data and their is no potential loss of information.
Con(s) - We ultimately push the problem of parsing the number correctly to the consumer.

2. We could simply write the number as a string to postgres.

Pro(s) - This is easy to implement and parse. Easy to reason over what gets stored in the database and passed back through over the Haskell interface.
Con(s) - This is an inefficient use of space.

3. We could write the number as a type that could be translated to a numeric type in postgres.

Pro(s) - "natural" representation for later analysis AND potentially most efficient use of storage.

Con(s) - Could be hard to get an accurate representation.