### PR TITLE
Extend the account search endpoint with continuation

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: 11781f6d6137f525b6b6d419dd720dea18cd67a5
+    tag: fe3b281ab8e6e339ec04896e597e64868179c338
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: fe3b281ab8e6e339ec04896e597e64868179c338
+    tag: 17104fb7169c65158580140a25d2e9dd2f5ad1c0
 
 source-repository-package
     type: git

--- a/deps/chainweb-api/github.json
+++ b/deps/chainweb-api/github.json
@@ -3,6 +3,6 @@
   "repo": "chainweb-api",
   "branch": "master",
   "private": false,
-  "rev": "11781f6d6137f525b6b6d419dd720dea18cd67a5",
-  "sha256": "076phihlnhw1a2rdjjwfn3zsmiibd0lapvcr01m6wwb7zi3z57nh"
+  "rev": "fe3b281ab8e6e339ec04896e597e64868179c338",
+  "sha256": "1c5j1lby5k2j6dlld2h0jmfpbxpyjl93x6hmwyh9m08a19slh1c2"
 }

--- a/deps/chainweb-api/github.json
+++ b/deps/chainweb-api/github.json
@@ -3,6 +3,6 @@
   "repo": "chainweb-api",
   "branch": "master",
   "private": false,
-  "rev": "fe3b281ab8e6e339ec04896e597e64868179c338",
+  "rev": "17104fb7169c65158580140a25d2e9dd2f5ad1c0",
   "sha256": "1c5j1lby5k2j6dlld2h0jmfpbxpyjl93x6hmwyh9m08a19slh1c2"
 }

--- a/exec/Chainweb/Server.hs
+++ b/exec/Chainweb/Server.hs
@@ -462,8 +462,9 @@ accountHandler logger pool req account token chain fromHeight limit offset mbNex
           then noHeader
           else case lastMay r of
                  Nothing -> noHeader
-                 Just tr -> addHeader $ NextToken $ T.pack $ show @AccountNextToken
-                   (_tr_height tr, toS $ BS.filter (/= 0x3d) $ B64.encode $ toS $ show $ _tr_requestkey tr, _tr_idx tr )
+                 Just tr -> addHeader $ NextToken $ T.pack $
+                   toS $ BS.filter (/= 0x3d) $ B64.encode $ toS $ show @AccountNextToken
+                     (_tr_height tr, toS $ show $ _tr_requestkey tr, _tr_idx tr )
     return $ withHeader $ (`map` r) $ \tr -> AccountDetail
       { _acDetail_name = _tr_modulename tr
       , _acDetail_chainid = fromIntegral $ _tr_chainid tr

--- a/exec/Chainweb/Server.hs
+++ b/exec/Chainweb/Server.hs
@@ -441,7 +441,10 @@ accountHandler logger pool req account token chain fromHeight limit offset = do
     Nothing -> return 0
   liftIO $ P.withResource pool $ \c -> do
     let boundedLimit = Limit $ maybe 20 (min 100 . unLimit) limit
-    r <- runBeamPostgresDebug (logger Debug . T.pack) c $ runSelectReturningList $ accountQueryStmt boundedLimit boundedOffset account (fromMaybe "coin" token) chain fromHeight
+        queryStart = AQSNewQuery fromHeight boundedOffset
+    r <- runBeamPostgresDebug (logger Debug . T.pack) c $
+      runSelectReturningList $
+        accountQueryStmt boundedLimit account (fromMaybe "coin" token) chain queryStart
     return $ (`map` r) $ \tr -> AccountDetail
       { _acDetail_name = _tr_modulename tr
       , _acDetail_chainid = fromIntegral $ _tr_chainid tr


### PR DESCRIPTION
This PR extends the `/txs/account` endpoint to allow a simple, robust and efficient way to fetch the results of an account transfers search in a sequence of batches. Whenever a `/txs/accounts` request produces more results than the `limit` parameter, the response contains a `Chainweb-Next` response header containing a Base64-URL-encoded token. This token can then be passed to subsequent search requests to the same account via the `next` query parameter in order to fetch any further results.

Unlike the `limit` & `offset` way of fetching result batches, this method is more efficient, because the encoded token contains hints used for making it efficient to resume the search and it's also more robust for the client, because even if new blocks appear on the network, subsequent fetches should return a mutually exclusive set of rows, avoiding potential visual glitches or duplicated data.