### PR TITLE
Add a CLI option to ignore detected schema diffs

### DIFF
--- a/lib/ChainwebData/Env.hs
+++ b/lib/ChainwebData/Env.hs
@@ -58,7 +58,7 @@ import           Text.Printf
 
 ---
 
-data MigrateStatus = RunMigration | DontMigrate
+data MigrateStatus = RunMigration | DontMigrate Bool
   deriving (Eq,Ord,Show,Read)
 
 data Args
@@ -215,8 +215,13 @@ envP = Args
   <*> migrationP
 
 migrationP :: Parser MigrateStatus
-migrationP =
-  flag DontMigrate RunMigration (short 'm' <> long "migrate" <> help "Run DB migration")
+migrationP
+    = flag' RunMigration (short 'm' <> long "migrate" <> help "Run DB migration")
+  <|> flag' (DontMigrate False)
+        ( long "--ignore-schema-diff"
+       <> help "Ignore any unexpected differences in the database schema"
+        )
+  <|> pure (DontMigrate True)
 
 logLevelParser :: Parser LogLevel
 logLevelParser =

--- a/lib/ChainwebData/Env.hs
+++ b/lib/ChainwebData/Env.hs
@@ -217,11 +217,11 @@ envP = Args
 migrationP :: Parser MigrateStatus
 migrationP
     = flag' RunMigration (short 'm' <> long "migrate" <> help "Run DB migration")
-  <|> flag' (DontMigrate False)
-        ( long "--ignore-schema-diff"
+  <|> flag' (DontMigrate True)
+        ( long "ignore-schema-diff"
        <> help "Ignore any unexpected differences in the database schema"
         )
-  <|> pure (DontMigrate True)
+  <|> pure (DontMigrate False)
 
 logLevelParser :: Parser LogLevel
 logLevelParser =

--- a/lib/ChainwebDb/Database.hs
+++ b/lib/ChainwebDb/Database.hs
@@ -27,6 +27,7 @@ import           ChainwebDb.Types.MinerKey
 import           ChainwebDb.Types.Signer
 import           ChainwebDb.Types.Transaction
 import           ChainwebDb.Types.Transfer
+import           Control.Monad (unless)
 import           Data.Functor ((<&>))
 import qualified Data.Pool as P
 import           Data.Text (Text)
@@ -175,10 +176,12 @@ initializeTables logg migrateStatus conn = do
           RunMigration -> do
             BA.tryRunMigrationsWithEditUpdate annotatedDb conn
             logg Info "Done with database migration."
-          DontMigrate -> do
-            logg Info "Database needs to be migrated.  Re-run with the -m option or you can migrate by hand with the following query:"
+          DontMigrate ignoreDiffs -> do
+            logg Info "Database needs to be migrated."
             showMigration conn
-            exitFailure
+            unless ignoreDiffs $ do
+              logg Error "Re-run with the -m option or you can run the queries above manually"
+              exitFailure
 
 
 


### PR DESCRIPTION
This PR adds an `--ignore-schema-diff` CLI option to the `chainweb-data` binary that makes it keep going even if it encounters a different schema in the database.

This option is useful for `chainweb-data` operators that would like to make ad-hoc additions to their CW-D database. Though it should probably be mentioned that making such ad-hoc changes, especially directly on the tables populated and queried by `chainweb-data` isn't officially supported since an arbitrarily different schema might cause CW-D to break in unpredictable ways.