### PR TITLE
enis/ignore schema diffs option

### DIFF
--- a/lib/ChainwebData/Env.hs
+++ b/lib/ChainwebData/Env.hs
@@ -58,7 +58,7 @@ import           Text.Printf
 
 ---
 
-data MigrateStatus = RunMigration | DontMigrate
+data MigrateStatus = RunMigration | DontMigrate Bool
   deriving (Eq,Ord,Show,Read)
 
 data Args
@@ -215,8 +215,13 @@ envP = Args
   <*> migrationP
 
 migrationP :: Parser MigrateStatus
-migrationP =
-  flag DontMigrate RunMigration (short 'm' <> long "migrate" <> help "Run DB migration")
+migrationP
+    = flag' RunMigration (short 'm' <> long "migrate" <> help "Run DB migration")
+  <|> flag' (DontMigrate False)
+        ( long "--ignore-schema-diff"
+       <> help "Ignore any unexpected differences in the database schema"
+        )
+  <|> pure (DontMigrate True)
 
 logLevelParser :: Parser LogLevel
 logLevelParser =

--- a/lib/ChainwebDb/Database.hs
+++ b/lib/ChainwebDb/Database.hs
@@ -27,6 +27,7 @@ import           ChainwebDb.Types.MinerKey
 import           ChainwebDb.Types.Signer
 import           ChainwebDb.Types.Transaction
 import           ChainwebDb.Types.Transfer
+import           Control.Monad (unless)
 import           Data.Functor ((<&>))
 import qualified Data.Pool as P
 import           Data.Text (Text)
@@ -175,10 +176,12 @@ initializeTables logg migrateStatus conn = do
           RunMigration -> do
             BA.tryRunMigrationsWithEditUpdate annotatedDb conn
             logg Info "Done with database migration."
-          DontMigrate -> do
-            logg Info "Database needs to be migrated.  Re-run with the -m option or you can migrate by hand with the following query:"
+          DontMigrate ignoreDiffs -> do
+            logg Info "Database needs to be migrated."
             showMigration conn
-            exitFailure
+            unless ignoreDiffs $ do
+              logg Error "Re-run with the -m option or you can run the queries above manually"
+              exitFailure
 
 
 


### PR DESCRIPTION
- Add a CLI option to ignore detected schema diffs
- fix: invert values for `DontMigrate`. Define long flag without dashes
