### PR TITLE
fix: invert values for DontMigrate. Define long flag without dashes

### DIFF
--- a/lib/ChainwebData/Env.hs
+++ b/lib/ChainwebData/Env.hs
@@ -217,11 +217,11 @@ envP = Args
 migrationP :: Parser MigrateStatus
 migrationP
     = flag' RunMigration (short 'm' <> long "migrate" <> help "Run DB migration")
-  <|> flag' (DontMigrate False)
-        ( long "--ignore-schema-diff"
+  <|> flag' (DontMigrate True)
+        ( long "ignore-schema-diff"
        <> help "Ignore any unexpected differences in the database schema"
         )
-  <|> pure (DontMigrate True)
+  <|> pure (DontMigrate False)
 
 logLevelParser :: Parser LogLevel
 logLevelParser =


### PR DESCRIPTION
- Add a CLI option to ignore detected schema diffs
- fix: invert values for `DontMigrate`. Define long flag without dashes
