### PR TITLE
Remove the fromheight parameter of /txs/accounts

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: a4f32aaf0af6de3d4393b804cb79aef8bc436185
+    tag: 953019e5eedc1d23833cb7b5b6c5f53627ff2b20
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: 6ffcf6265309bcd08034652523c940e4b71e9153
+    tag: a4f32aaf0af6de3d4393b804cb79aef8bc436185
 
 source-repository-package
     type: git

--- a/deps/chainweb-api/github.json
+++ b/deps/chainweb-api/github.json
@@ -3,6 +3,6 @@
   "repo": "chainweb-api",
   "branch": "master",
   "private": false,
-  "rev": "6ffcf6265309bcd08034652523c940e4b71e9153",
-  "sha256": "1pagn20ss7w6llck75d2yvcjv1lji31knd39fppc6a8av64n6n8g"
+  "rev": "953019e5eedc1d23833cb7b5b6c5f53627ff2b20",
+  "sha256": "1q33fkigjk34z101jb7j827bfp3hhhglqip6rxvqpg09p26nc03p"
 }

--- a/lib/ChainwebDb/Queries.hs
+++ b/lib/ChainwebDb/Queries.hs
@@ -167,7 +167,7 @@ _bytequery = \case
   SqlSelect s -> pgRenderSyntaxScript $ fromPgSelect s
 
 data AccountQueryStart
-  = AQSNewQuery (Maybe BlockHeight) Offset
+  = AQSNewQuery Offset
   | AQSContinue BlockHeight ReqKeyOrCoinbase Int
 
 accountQueryStmt
@@ -202,8 +202,7 @@ accountQueryStmt (Limit limit) account token chain aqs =
       rowFilter tr
       return (tr,_block_creationTime blk)
     (Offset offset, rowFilter) = case aqs of
-      AQSNewQuery mbHeight ofst -> (,) ofst $ \tr ->
-        whenArg mbHeight $ \bh -> guard_ $ _tr_height tr <=. val_ (fromIntegral bh)
+      AQSNewQuery ofst -> (ofst, const $ return ())
       AQSContinue height reqKey idx -> (,) (Offset 0) $ \tr ->
         guard_ $ tupleCmp (<.)
           [ _tr_height tr :<> fromIntegral height


### PR DESCRIPTION
This PR removes the yet unreleased `fromheight` parameter of the `/txs/accounts` endpoint.

The original purpose of that parameter was to facilitate efficient pagination of the `/txs/accounts` results, but it has since been obsoleted for that purpose by the `Chainweb-Next`-token-based pagination workflow. The `Chainweb-Next`-based pagination is superior, because it doesn't require the client to figure out how to stitch together the result chunks produced by each request and it is easier to reuse across endpoints independent of whether specifying `height` limits is a reasonable or efficient way to paginate for a given endpoint.

Admittedly, `fromheight` could still be useful independent of pagination, but I'm not convinced that adding query parameters to `chainweb-data` endpoints for hypothetical use cases is a good idea at this stage, especially considering the backward compatibility burden that entails.