### PR TITLE
Add migrate command to chainweb-data CLI

### DIFF
--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -46,6 +46,8 @@ main = do
     withLogger (config (getLevel args)) backend $ \logger -> do
       let logg = loggerFunIO logger
       case args of
+        MigrateOnly pgc _ -> withPool pgc $ \pool ->
+          runMigrations pool logg RunMigration False
         RichListArgs (NodeDbPath mfp) _ version -> do
           fp <- case mfp of
             Nothing -> do
@@ -62,18 +64,7 @@ main = do
           logg Info $ "Service API: " <> fromString (showUrlScheme us)
           logg Info $ "P2P API: " <> fromString (showUrlScheme (UrlScheme Https u))
           withPool pgc $ \pool -> do
-            P.withResource pool $ \conn ->
-              unless (isIndexedDisabled c) $ do
-                initializeTables logg ms conn
-                addTransactionsHeightIndex logg conn
-                addEventsHeightChainIdIdxIndex logg conn
-                addEventsHeightNameParamsIndex logg conn
-                addFromAccountsIndex logg conn
-                addToAccountsIndex logg conn
-                addTransactionsRequestKeyIndex logg conn
-                addEventsRequestKeyIndex logg conn
-                initializePGSimpleMigrations logg conn
-            logg Info "DB Tables Initialized"
+            runMigrations pool logg ms (isIndexedDisabled c)
             let mgrSettings = mkManagerSettings (TLSSettingsSimple True False False) Nothing
             m <- newManager mgrSettings
             getNodeInfo m us >>= \case
@@ -93,7 +84,7 @@ main = do
                       FillEvents as et -> fillEvents env as et
                       Server serverEnv -> apiServer env serverEnv
   where
-    opts = info ((richListP <|> envP) <**> helper)
+    opts = info ((richListP <|> migrateOnlyP <|> envP) <**> helper)
       (fullDesc <> header "chainweb-data - Processing and analysis of Chainweb data")
     config level = defaultLoggerConfig
       & loggerConfigThreshold .~ level
@@ -104,6 +95,23 @@ main = do
     getLevel = \case
       Args _ _ _ _ level _ -> level
       RichListArgs _ level _ -> level
+      MigrateOnly _ level -> level
+
+runMigrations ::
+  P.Pool Connection -> LogFunctionIO Text -> MigrateStatus -> Bool -> IO ()
+runMigrations pool logg ms indexesDisabled = do
+  P.withResource pool $ \conn ->
+    unless indexesDisabled $ do
+      initializeTables logg ms conn
+      addTransactionsHeightIndex logg conn
+      addEventsHeightChainIdIdxIndex logg conn
+      addEventsHeightNameParamsIndex logg conn
+      addFromAccountsIndex logg conn
+      addToAccountsIndex logg conn
+      addTransactionsRequestKeyIndex logg conn
+      addEventsRequestKeyIndex logg conn
+      initializePGSimpleMigrations logg conn
+  logg Info "DB Tables Initialized"
 
 
 data IndexCreationInfo = IndexCreationInfo

--- a/lib/ChainwebData/Env.hs
+++ b/lib/ChainwebData/Env.hs
@@ -20,6 +20,7 @@ module ChainwebData.Env
   , BackfillArgs(..)
   , FillArgs(..)
   , envP
+  , migrateOnlyP
   , richListP
   , NodeDbPath(..)
   , progress
@@ -66,6 +67,7 @@ data Args
     -- ^ arguments for all but the richlist command
   | RichListArgs NodeDbPath LogLevel ChainwebVersion
     -- ^ arguments for the Richlist command
+  | MigrateOnly Connect LogLevel
   deriving (Show)
 
 data Env = Env
@@ -208,7 +210,7 @@ data ServerEnv = ServerEnv
 envP :: Parser Args
 envP = Args
   <$> commands
-  <*> (fromMaybe (PGGargoyle "cwdb-pgdata") <$> optional connectP)
+  <*> connectP
   <*> urlSchemeParser "service" 1848
   <*> urlParser "p2p" 443
   <*> logLevelParser
@@ -229,6 +231,18 @@ logLevelParser =
       long "level"
       <> value Info
       <> help "Initial log threshold"
+
+migrateOnlyP :: Parser Args
+migrateOnlyP = hsubparser
+  ( command "migrate"
+    ( info opts $ progDesc
+        "Run the database migrations only"
+    )
+  )
+  where
+    opts = MigrateOnly
+      <$> connectP
+      <*> logLevelParser
 
 richListP :: Parser Args
 richListP = hsubparser
@@ -262,7 +276,10 @@ simpleVersionParser =
     <> help "Chainweb node version"
 
 connectP :: Parser Connect
-connectP = (PGString <$> pgstringP) <|> (PGInfo <$> connectInfoP) <|> (PGGargoyle <$> dbdirP)
+connectP = (PGString <$> pgstringP)
+       <|> (PGInfo <$> connectInfoP)
+       <|> (PGGargoyle <$> dbdirP)
+       <|> pure (PGGargoyle "cwdb-pgdata")
 
 dbdirP :: Parser FilePath
 dbdirP = strOption (long "dbdir" <> help "Directory for self-run postgres")


### PR DESCRIPTION
This PR is a part of the incremental script-based migration transition #101.

This PR adds a `migrate` subcommand to `chainweb-data` that can be used to just run migrations and exit. This will be useful for the post-script-based-migration version; When that version encounters a database that's too old, it'll ask the user to download the latest `beam-automigrate`-based CW-D version (the upcoming release) and run it in this PR's `migrate` mode so that the database can be used with future versions that know how do migrate it incrementally from the last `beam-automigrate`-based database state.