### PR TITLE
Represent transfer amount as JSON string-encoded numbers

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: 953019e5eedc1d23833cb7b5b6c5f53627ff2b20
+    tag: 2d471e236ad18d5e7d2405fc1707dad8b80f49d2
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: 2d471e236ad18d5e7d2405fc1707dad8b80f49d2
+    tag: 5ca78695338638195d73c27a5d1854d63e947e1a
 
 source-repository-package
     type: git

--- a/chainweb-data.cabal
+++ b/chainweb-data.cabal
@@ -44,7 +44,7 @@ common commons
     , lens
     , lens-aeson
     , postgresql-simple
-    , resource-pool      >= 0.3
+    , resource-pool      >= 0.3 && <0.4
     , safe
     , scientific         ^>=0.3
     , servant
@@ -212,7 +212,7 @@ benchmark bench
     , http-client              ^>=0.6
     , optparse-applicative     >=0.14 && <0.17
     , postgresql-simple
-    , resource-pool      >= 0.3
+    , resource-pool      >= 0.3 && <0.4
     , string-conv
     , text
     , time               >=1.8      && <1.11

--- a/deps/chainweb-api/github.json
+++ b/deps/chainweb-api/github.json
@@ -3,6 +3,6 @@
   "repo": "chainweb-api",
   "branch": "master",
   "private": false,
-  "rev": "953019e5eedc1d23833cb7b5b6c5f53627ff2b20",
-  "sha256": "1q33fkigjk34z101jb7j827bfp3hhhglqip6rxvqpg09p26nc03p"
+  "rev": "2d471e236ad18d5e7d2405fc1707dad8b80f49d2",
+  "sha256": "1mnnl9b1qxxswh29alcv865fhm3ryfknmw1mcirhqdiijawmc9nd"
 }

--- a/deps/chainweb-api/github.json
+++ b/deps/chainweb-api/github.json
@@ -3,6 +3,6 @@
   "repo": "chainweb-api",
   "branch": "master",
   "private": false,
-  "rev": "2d471e236ad18d5e7d2405fc1707dad8b80f49d2",
+  "rev": "5ca78695338638195d73c27a5d1854d63e947e1a",
   "sha256": "1mnnl9b1qxxswh29alcv865fhm3ryfknmw1mcirhqdiijawmc9nd"
 }

--- a/exec/Chainweb/Server.hs
+++ b/exec/Chainweb/Server.hs
@@ -64,6 +64,7 @@ import           Text.Printf
 ------------------------------------------------------------------------------
 import           Chainweb.Api.BlockPayloadWithOutputs
 import           Chainweb.Api.Common (BlockHeight)
+import           Chainweb.Api.StringEncoded (StringEncoded(..))
 import           Chainweb.Coins
 import           ChainwebDb.Database
 import           ChainwebDb.Queries
@@ -555,7 +556,7 @@ accountHandler logger pool req account token chain limit mbOffset mbNext = do
 
   continuation <- mkContinuation readEventToken mbOffset mbNext
   isBounded <- isBoundedStrategyM req
-  let searchParams = TransferSearchParams 
+  let searchParams = TransferSearchParams
        { tspToken = usedCoinType
        , tspChainId = chain
        , tspAccount = account
@@ -581,7 +582,7 @@ accountHandler logger pool req account token chain limit mbOffset mbNext = do
         , _acDetail_blockHash = unDbHash $ unBlockId $ _tr_block tr
         , _acDetail_requestKey = getTxHash $ _tr_requestkey tr
         , _acDetail_idx = fromIntegral $ _tr_idx tr
-        , _acDetail_amount = getKDAScientific $ _tr_amount tr
+        , _acDetail_amount = StringEncoded $ getKDAScientific $ _tr_amount tr
         , _acDetail_fromAccount = _tr_from_acct tr
         , _acDetail_toAccount = _tr_to_acct tr
         , _acDetail_blockTime = tseBlockTime extras

--- a/lib/ChainwebData/Spec.hs
+++ b/lib/ChainwebData/Spec.hs
@@ -4,13 +4,15 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeOperators #-}
 
 module ChainwebData.Spec where
 
+
+import Control.Lens
 import ChainwebData.Api
 
 import Data.Proxy
@@ -28,6 +30,8 @@ import ChainwebData.Util
 import qualified Data.Aeson as A
 import ChainwebData.TxDetail
 import ChainwebData.AccountDetail (AccountDetail)
+import Chainweb.Api.StringEncoded (StringEncoded)
+import Data.Scientific (Scientific)
 
 instance ToSchema A.Value where
   declareNamedSchema _ = pure $ NamedSchema (Just "AnyValue") mempty
@@ -66,6 +70,12 @@ instance ToSchema AccountDetail where
 instance ToSchema ChainwebDataStats where
   declareNamedSchema = genericDeclareNamedSchema
     defaultSchemaOptions{ fieldLabelModifier = drop 5 }
+
+instance ToSchema (StringEncoded Scientific) where
+  declareNamedSchema _ = pure $ NamedSchema (Just "StringEncodedNumber") $ mempty
+    & type_ ?~ OpenApiString
+    & example ?~ A.String "-1234.5e6"
+    & pattern ?~ "[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?"
 
 spec :: OpenApi
 spec = toOpenApi (Proxy :: Proxy ChainwebDataApi)


### PR DESCRIPTION
This PR wraps the type of the transfer amount field in order to change its JSON representation to be a string literal containing a number (as opposed to a JSON number literal). 

The reason for this change is that [even though JSON-by-the-spec number literals are arbitrary-precision](https://github.com/kadena-io/chainweb-api/pull/30#issuecomment-1255044266), we've concluded that in practice, parsing JSON number literals with more precision than JS numbers can be unnecessarily hard and fragile using the JSON libraries of many popular languages.

Seems like this representation is commonplace in the blockchain world anyway, so it shouldn't be surprising for most of our users.

This PR also adds a `ToSchema` instance for `StringEncoded Scientific` that emits the following OpenAPI 3 schema for it:
``` json
{ 
  "type":"string",
  "pattern":"[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?",
  "example":"-1234.5e6"
}
```