### PR TITLE
Rename chainid,name to chain,token

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: ca794bec5e7b3a7e58f4862459b712b78191971b
+    tag: 38eb85b5395b575aa2efeff91fbfeb5cb3d494ce
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: 38eb85b5395b575aa2efeff91fbfeb5cb3d494ce
+    tag: 7a047fac0b0555d095c54cde6f53493a560034a9
 
 source-repository-package
     type: git

--- a/deps/chainweb-api/github.json
+++ b/deps/chainweb-api/github.json
@@ -3,6 +3,6 @@
   "repo": "chainweb-api",
   "branch": "master",
   "private": false,
-  "rev": "ca794bec5e7b3a7e58f4862459b712b78191971b",
-  "sha256": "03b79qrsflfqiij71y4fyq57lxf3skz2irj689j6y4mvzznx18xg"
+  "rev": "38eb85b5395b575aa2efeff91fbfeb5cb3d494ce",
+  "sha256": "10papx5p14y8192gc8mi1dq89vxhil8fci5j3skf5ijralxsj8f4"
 }

--- a/deps/chainweb-api/github.json
+++ b/deps/chainweb-api/github.json
@@ -3,6 +3,6 @@
   "repo": "chainweb-api",
   "branch": "master",
   "private": false,
-  "rev": "38eb85b5395b575aa2efeff91fbfeb5cb3d494ce",
+  "rev": "7a047fac0b0555d095c54cde6f53493a560034a9",
   "sha256": "10papx5p14y8192gc8mi1dq89vxhil8fci5j3skf5ijralxsj8f4"
 }

--- a/exec/Chainweb/Server.hs
+++ b/exec/Chainweb/Server.hs
@@ -575,8 +575,8 @@ accountHandler logger pool req account token chain limit mbOffset mbNext = do
         continuation
         resultLimit
       return $ maybe noHeader (addHeader . mkEventToken) mbCont  $ results <&> \(tr, extras) -> TransferDetail
-        { _trDetail_name = _tr_modulename tr
-        , _trDetail_chainid = fromIntegral $ _tr_chainid tr
+        { _trDetail_token = _tr_modulename tr
+        , _trDetail_chain = fromIntegral $ _tr_chainid tr
         , _trDetail_height = fromIntegral $ _tr_height tr
         , _trDetail_blockHash = unDbHash $ unBlockId $ _tr_block tr
         , _trDetail_requestKey = getTxHash $ _tr_requestkey tr


### PR DESCRIPTION
That's because:
* We have a query parameter called "token" that's used to filter on that field, so no reason to have a different name, and "token" makes more sense anyway
* The same goes with the "chain" query parameter, but "chainid" is also inconsistent with the events and search endpoints

Note that this is a breaking change on top of v2.1.0, but I think the improvement in consistency is worth it, especially considering that we've released v2.1.0 2 days ago and haven't yet announced it over any of the official or unofficial channels.