### PR TITLE
Bump v2.1.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ This is a quick release after 2.1.0 for fixing an oversight in the new `/txs/acc
 
 ## 2.1.0 (2023-01-17)
 
-*IMPORTANT NOTICE*: Please skip this chainweb-data release and go straight to 2.1.1. Shortly after the release, we've noticed an oversight in the new `/txs/account` endpoint and decided to correct it with a quick breaking change instead of unnecessarily complicating the API. See [PR #126](https://github.com/kadena-io/chainweb-data/pull/126).
+_**IMPORTANT NOTICE**: Please skip this chainweb-data release and go straight to 2.1.1. Shortly after the release, we've noticed an oversight in the new `/txs/account` endpoint and decided to correct it with a quick breaking change instead of unnecessarily complicating the API. See [PR #126](https://github.com/kadena-io/chainweb-data/pull/126)._
 
 This release drops the officiall support for Ubuntu 18.04 and adds support for Ubuntu 22.04 (see #100)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.1.1 (2023-01-20)
+## 2.1.1 (2023-01-23)
 
 This is a quick release after 2.1.0 for fixing an oversight in the new `/txs/accounts` endpoint.
 * Rename `chainid` -> `chain`, `name` -> `token` fields of `/txs/accounts` for consistency (#126)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 2.1.0 (2023-01-05)
+## 2.1.1 (2023-01-20)
+
+This is a quick release after 2.1.0 for fixing an oversight in the new `/txs/accounts` endpoint.
+* Rename `chainid` -> `chain`, `name` -> `token` fields of `/txs/accounts` for consistency (#126)
+* Implement a `minheight` parameter for `/txs/accounts` (#127)
+
+## 2.1.0 (2023-01-17)
+
+*IMPORTANT NOTICE*: Please skip this chainweb-data release and go straight to 2.1.1. Shortly after the release, we've noticed an oversight in the new `/txs/account` endpoint and decided to correct it with a quick breaking change instead of unnecessarily complicating the API. See [PR #126](https://github.com/kadena-io/chainweb-data/pull/126).
 
 This release drops the officiall support for Ubuntu 18.04 and adds support for Ubuntu 22.04 (see #100)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,8 @@
 
 This is a quick release after 2.1.0 for fixing an oversight in the new `/txs/accounts` endpoint.
 * Rename `chainid` -> `chain`, `name` -> `token` fields of `/txs/accounts` for consistency (#126)
-* Implement a `minheight` parameter for `/txs/accounts` (#127)
+* A new `minheight` parameter for `/txs/accounts` (#127)
+* A `docker.nix` definition for building Ubuntu-based `chainweb-data` docker images using Nix (#84)
 
 ## 2.1.0 (2023-01-17)
 

--- a/chainweb-data.cabal
+++ b/chainweb-data.cabal
@@ -1,6 +1,6 @@
 cabal-version:   2.2
 name:            chainweb-data
-version:         2.1.0
+version:         2.1.1
 description:     Data ingestion for Chainweb.
 homepage:        https://github.com/kadena-io/chainweb-data
 author:          Colin Woodbury


### PR DESCRIPTION
Shortly after the 2.1.0 release, we've noticed an oversight in the new `/txs/account` endpoint and decided to correct it with a quick breaking change instead of unnecessarily complicating the API. See [PR #126](https://github.com/kadena-io/chainweb-data/pull/126)