### PR TITLE
Add height range params to tx search endpoitns

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,7 +18,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: 228317c6f298f22915ca4955db745a28363c42ef
+    tag: db1ea259f9e1bb8412fb185160cad29f1f9c8227
     --sha256: sha256-MY470zn+BveL7X7gFVSgGqvWjD0jsk6VKRF/gzal9Bc=
 
 source-repository-package

--- a/cabal.project
+++ b/cabal.project
@@ -18,8 +18,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: dedd563432d53b39fa6553a3e6c551b471e7483f
-    --sha256: sha256-qd7dInRCi+C61Xo8uXcAsAkutOd+pFDjglHBhPD8Uw4=
+    tag: 228317c6f298f22915ca4955db745a28363c42ef
+    --sha256: sha256-MY470zn+BveL7X7gFVSgGqvWjD0jsk6VKRF/gzal9Bc=
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -18,7 +18,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: db1ea259f9e1bb8412fb185160cad29f1f9c8227
+    tag: 8a4731c2875753617ccd2b573cf726fa100c6053
     --sha256: sha256-MY470zn+BveL7X7gFVSgGqvWjD0jsk6VKRF/gzal9Bc=
 
 source-repository-package

--- a/haskell-src/exec/Chainweb/Server.hs
+++ b/haskell-src/exec/Chainweb/Server.hs
@@ -393,7 +393,7 @@ searchTxs logger pool req givenMbLim mbOffset (Just search) minheight maxheight 
       (mbCont, results) <- performBoundedScan strategy
         (runBeamPostgresDebug (logger Debug . T.pack) c)
         toTxSearchCursor
-        (txSearchSource search $ HeightRangeParams maxheight minheight)
+        (txSearchSource search $ HeightRangeParams minheight maxheight)
         noDecoration
         continuation
         resultLimit
@@ -562,7 +562,7 @@ accountHandler logger pool req account token chain minheight maxheight limit mbO
   let searchParams = TransferSearchParams
        { tspToken = usedCoinType
        , tspChainId = chain
-       , tspHeightRange = HeightRangeParams maxheight minheight
+       , tspHeightRange = HeightRangeParams minheight maxheight
        , tspAccount = account
        }
   liftIO $ M.with pool $ \(c, throttling) -> do
@@ -648,7 +648,7 @@ evHandler logger pool req limit mbOffset qSearch qParam qName qModuleName minhei
       (mbCont, results) <- performBoundedScan strategy
         (runBeamPostgresDebug (logger Debug . T.pack) c)
         toEventsSearchCursor
-        (eventsSearchSource searchParams $ HeightRangeParams maxheight minheight)
+        (eventsSearchSource searchParams $ HeightRangeParams minheight maxheight)
         eventSearchExtras
         continuation
         resultLimit

--- a/haskell-src/lib/ChainwebDb/Queries.hs
+++ b/haskell-src/lib/ChainwebDb/Queries.hs
@@ -47,14 +47,14 @@ type PgExpr s = QGenExpr QValueContext Postgres s
 type PgBaseExpr = PgExpr QBaseScope
 
 data HeightRangeParams = HeightRangeParams
-  { hrpMaxHeight :: Maybe BlockHeight
-  , hrpMinHeight :: Maybe BlockHeight
+  { hrpMinHeight :: Maybe BlockHeight
+  , hrpMaxHeight :: Maybe BlockHeight
   }
 
 guardInRange :: HeightRangeParams -> PgExpr s Int64 -> Q Postgres db s ()
 guardInRange HeightRangeParams{..} hgt = do
-  whenArg hrpMaxHeight $ \h -> guard_ $ hgt <=. val_ (fromIntegral h)
   whenArg hrpMinHeight $ \h -> guard_ $ hgt >=. val_ (fromIntegral h)
+  whenArg hrpMaxHeight $ \h -> guard_ $ hgt <=. val_ (fromIntegral h)
 
 -- | A subset of the TransactionT record, used with beam for querying the
 -- /txs/search endpoint response payload


### PR DESCRIPTION
This PR adds `maxheight` parameters to the `/txs/events` and `/txs/account` endpoints, while adding both `maxheight` and `minheight` to `/txs/search`.