### PR TITLE
Gather XChain info for transfers

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,8 +18,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: 8a4731c2875753617ccd2b573cf726fa100c6053
-    --sha256: sha256-MY470zn+BveL7X7gFVSgGqvWjD0jsk6VKRF/gzal9Bc=
+    tag: e5e504b3b34bf69b485a088d8053fc1049f126dd
+    --sha256: sha256-TwSIofHKH030Wt1XIGlPVaiOdlWBr928pDehr+wETAw=
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -18,8 +18,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: e5e504b3b34bf69b485a088d8053fc1049f126dd
-    --sha256: sha256-TwSIofHKH030Wt1XIGlPVaiOdlWBr928pDehr+wETAw=
+    tag: c877d32b46175917d9df9521d0c4e7ec47ebd5cd
+    --sha256: sha256-X6fQTcV46lHT3vifSDO0exnoYBr7Tx2YEpK8EyEFgBA=
 
 source-repository-package
     type: git

--- a/haskell-src/exec/Chainweb/Server.hs
+++ b/haskell-src/exec/Chainweb/Server.hs
@@ -589,8 +589,8 @@ accountHandler logger pool req account token chain minheight maxheight limit mbO
         , _trDetail_amount = StringEncoded $ getKDAScientific $ _tr_amount tr
         , _trDetail_fromAccount = _tr_from_acct tr
         , _trDetail_toAccount = _tr_to_acct tr
-        , _trDetail_xchainAccount = tseXChainAccount extras
-        , _trDetail_xchainId = fromIntegral <$> tseXChainId extras
+        , _trDetail_crossChainAccount = tseXChainAccount extras
+        , _trDetail_crossChainId = fromIntegral <$> tseXChainId extras
         , _trDetail_blockTime = tseBlockTime extras
         }
 

--- a/haskell-src/exec/Chainweb/Server.hs
+++ b/haskell-src/exec/Chainweb/Server.hs
@@ -589,6 +589,8 @@ accountHandler logger pool req account token chain minheight maxheight limit mbO
         , _trDetail_amount = StringEncoded $ getKDAScientific $ _tr_amount tr
         , _trDetail_fromAccount = _tr_from_acct tr
         , _trDetail_toAccount = _tr_to_acct tr
+        , _trDetail_xchainAccount = Nothing
+        , _trDetail_xchainId = Nothing
         , _trDetail_blockTime = tseBlockTime extras
         }
 

--- a/haskell-src/exec/Chainweb/Server.hs
+++ b/haskell-src/exec/Chainweb/Server.hs
@@ -589,8 +589,8 @@ accountHandler logger pool req account token chain minheight maxheight limit mbO
         , _trDetail_amount = StringEncoded $ getKDAScientific $ _tr_amount tr
         , _trDetail_fromAccount = _tr_from_acct tr
         , _trDetail_toAccount = _tr_to_acct tr
-        , _trDetail_xchainAccount = Nothing
-        , _trDetail_xchainId = Nothing
+        , _trDetail_xchainAccount = tseXChainAccount extras
+        , _trDetail_xchainId = fromIntegral <$> tseXChainId extras
         , _trDetail_blockTime = tseBlockTime extras
         }
 

--- a/haskell-src/lib/ChainwebDb/Queries.hs
+++ b/haskell-src/lib/ChainwebDb/Queries.hs
@@ -244,7 +244,7 @@ joinXChainInfo :: TransferT (PgExpr s) ->
   Q Postgres ChainwebDataDb s (XChainInfoT (PgExpr s))
 joinXChainInfo tr = pgUnnest $ (customExpr_ $ \fromAcct toAcct idx mdName blk req amt ->
   -- We need the following LATERAL keyword so that it can be used liberally
-  -- in any Q context despite the fact that it refers to the `pactIdExp` coming
+  -- in any Q context despite the fact that it refers to the `tr` coming
   -- from the outside scope. The LATERAL helps, because when the expression below
   -- appears after a XXXX JOIN, this LATERAL prefix will turn it into a lateral
   -- join. This is very hacky, but Postgres allows the LATERAL keyword after FROM


### PR DESCRIPTION
This PR extends the transfer search queries to attach cross-chain information to cross-chain transfer rows. For the send-side of cross-chain transactions it extracts the intended receiver from the corresponding `TRANSFER_XCHAIN` event of the same transaction and for the receive-side, it chases the `pactid` of the associated transaction and looks for a matching `TRANSFER_XCHAIN`. 