### PR TITLE
Implement script-based migrations

### DIFF
--- a/haskell-src/chainweb-data.cabal
+++ b/haskell-src/chainweb-data.cabal
@@ -66,6 +66,7 @@ library
     ChainwebData.Spec
     ChainwebDb.BoundedScan
     ChainwebDb.Database
+    ChainwebDb.Migration
     ChainwebDb.Queries
     ChainwebDb.Types.Block
     ChainwebDb.Types.Common
@@ -77,6 +78,7 @@ library
     ChainwebDb.Types.Transfer
   build-depends:
     base64-bytestring        ^>=1.0
+    , cryptohash
     , Decimal
     , gargoyle
     , gargoyle-postgresql
@@ -85,6 +87,7 @@ library
     , http-types
     , openapi3
     , optparse-applicative     >=0.14 && <0.17
+    , postgresql-simple-migration
     , servant-client
     , servant-openapi3
     , yet-another-logger
@@ -101,7 +104,7 @@ flag threaded
 executable chainweb-data
   import:         commons
   main-is:        Main.hs
-  hs-source-dirs: exec data
+  hs-source-dirs: exec data db-schema
   if flag(threaded)
       ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:

--- a/haskell-src/db-schema/init.sql
+++ b/haskell-src/db-schema/init.sql
@@ -1,0 +1,154 @@
+CREATE TABLE blocks (
+    chainid bigint NOT NULL,
+    creationtime timestamp with time zone NOT NULL,
+    epoch timestamp with time zone NOT NULL,
+    flags numeric(20,0) NOT NULL,
+    hash character varying NOT NULL,
+    height bigint NOT NULL,
+    miner character varying NOT NULL,
+    nonce numeric(20,0) NOT NULL,
+    parent character varying NOT NULL,
+    payload character varying NOT NULL,
+    powhash character varying NOT NULL,
+    predicate character varying NOT NULL,
+    target numeric(80,0) NOT NULL,
+    weight numeric(80,0) NOT NULL
+);
+
+ALTER TABLE ONLY blocks
+    ADD CONSTRAINT blocks_pkey PRIMARY KEY (hash);
+
+CREATE TABLE events (
+    block character varying NOT NULL,
+    chainid bigint NOT NULL,
+    height bigint NOT NULL,
+    idx bigint NOT NULL,
+    module character varying NOT NULL,
+    modulehash character varying NOT NULL,
+    name character varying NOT NULL,
+    params jsonb NOT NULL,
+    paramtext character varying NOT NULL,
+    qualname character varying NOT NULL,
+    requestkey character varying NOT NULL
+);
+
+ALTER TABLE ONLY events
+    ADD CONSTRAINT events_pkey PRIMARY KEY (block, idx, requestkey);
+
+ALTER TABLE ONLY events
+    ADD CONSTRAINT events_block_fkey FOREIGN KEY (block) REFERENCES blocks(hash);
+
+CREATE INDEX events_height_chainid_idx
+  ON events
+  USING btree (height DESC, chainid, idx);
+
+CREATE INDEX events_height_name_expr_expr1_idx
+  ON events
+  USING btree (height DESC, name, ((params ->> 0)), ((params ->> 1))) WHERE ((name)::text = 'TRANSFER'::text);
+
+CREATE INDEX events_requestkey_idx
+  ON events
+  USING btree (requestkey);
+
+CREATE TABLE minerkeys (
+    block character varying NOT NULL,
+    key character varying NOT NULL
+);
+
+ALTER TABLE ONLY minerkeys
+    ADD CONSTRAINT minerkeys_pkey PRIMARY KEY (block, key);
+
+ALTER TABLE ONLY minerkeys
+    ADD CONSTRAINT minerkeys_block_fkey FOREIGN KEY (block) REFERENCES blocks(hash);
+
+
+CREATE TABLE signers (
+    addr character varying,
+    caps jsonb NOT NULL,
+    idx integer NOT NULL,
+    pubkey character varying NOT NULL,
+    requestkey character varying NOT NULL,
+    scheme character varying,
+    sig character varying NOT NULL
+);
+
+ALTER TABLE ONLY signers
+    ADD CONSTRAINT signers_pkey PRIMARY KEY (idx, requestkey);
+
+
+CREATE TABLE transactions (
+    badresult jsonb,
+    block character varying NOT NULL,
+    chainid bigint NOT NULL,
+    code character varying,
+    continuation jsonb,
+    creationtime timestamp with time zone NOT NULL,
+    data jsonb,
+    gas bigint NOT NULL,
+    gaslimit bigint NOT NULL,
+    gasprice double precision NOT NULL,
+    goodresult jsonb,
+    height bigint NOT NULL,
+    logs character varying,
+    metadata jsonb,
+    nonce character varying NOT NULL,
+    num_events bigint,
+    pactid character varying,
+    proof character varying,
+    requestkey character varying NOT NULL,
+    rollback boolean,
+    sender character varying NOT NULL,
+    step bigint,
+    ttl bigint NOT NULL,
+    txid bigint
+);
+
+ALTER TABLE ONLY transactions
+    ADD CONSTRAINT transactions_pkey PRIMARY KEY (block, requestkey);
+
+ALTER TABLE ONLY transactions
+    ADD CONSTRAINT transactions_block_fkey FOREIGN KEY (block) REFERENCES blocks(hash);
+
+CREATE INDEX transactions_height_idx
+  ON transactions
+  USING btree (height);
+
+CREATE INDEX transactions_requestkey_idx
+  ON transactions
+  USING btree (requestkey);
+
+
+CREATE TABLE transfers (
+    amount numeric NOT NULL,
+    block character varying NOT NULL,
+    chainid bigint NOT NULL,
+    from_acct character varying NOT NULL,
+    height bigint NOT NULL,
+    idx bigint NOT NULL,
+    modulehash character varying NOT NULL,
+    modulename character varying NOT NULL,
+    requestkey character varying NOT NULL,
+    to_acct character varying NOT NULL
+);
+
+ALTER TABLE ONLY transfers
+    ADD CONSTRAINT transfers_pkey PRIMARY KEY (block, chainid, idx, modulehash, requestkey);
+
+CREATE INDEX transfers_from_acct_height_idx
+  ON transfers
+  USING btree (from_acct, height DESC, idx);
+
+
+CREATE INDEX transfers_to_acct_height_idx_idx
+  ON transfers
+  USING btree (to_acct, height DESC, idx);
+
+ALTER TABLE ONLY transfers
+    ADD CONSTRAINT transfers_block_fkey FOREIGN KEY (block) REFERENCES blocks(hash);
+
+
+CREATE TABLE schema_migrations (
+    filename character varying(512) NOT NULL,
+    checksum character varying(32) NOT NULL,
+    executed_at timestamp without time zone DEFAULT now() NOT NULL
+);

--- a/haskell-src/exec/Chainweb/Backfill.hs
+++ b/haskell-src/exec/Chainweb/Backfill.hs
@@ -86,7 +86,7 @@ backfillBlocksCut env args cutBS = do
       headersBetween env range >>= \case
         Left e -> logg Error $ fromString $ printf "ApiError for range %s: %s" (show range) (show e)
         Right [] -> logg Error $ fromString $ printf "headersBetween: %s" $ show range
-        Right hs -> writeBlocks env pool False count hs
+        Right hs -> writeBlocks env pool count hs
       delayFunc
 
 -- | For all blocks written to the DB, find the shortest (in terms of block

--- a/haskell-src/exec/Chainweb/Gaps.hs
+++ b/haskell-src/exec/Chainweb/Gaps.hs
@@ -17,7 +17,6 @@ import           ChainwebData.Types
 import           Control.Concurrent
 import           Control.Concurrent.Async
 import           Control.Monad
-import           Control.Monad.Catch
 import           Control.Scheduler
 import           Data.Bool
 import           Data.ByteString.Lazy (ByteString)
@@ -30,7 +29,6 @@ import           Data.Text (Text)
 import           Database.Beam hiding (insert)
 import           Database.Beam.Postgres
 import           Database.PostgreSQL.Simple
-import           Database.PostgreSQL.Simple.Types
 import           System.Logger hiding (logg)
 import           System.Exit (exitFailure)
 import           Text.Printf
@@ -72,13 +70,10 @@ gapsCut env args cutBS = do
                     (traverseConcurrently_ Par' doChain (M.toList gapsByChain))
               final <- readIORef count
               logg Info $ fromString $ printf "Filled in %d missing blocks." final
-        if disableIndexesPred
-          then withDroppedIndexes pool logg gapFiller
-          else gapFiller
+        gapFiller
   where
     pool = _env_dbConnPool env
     delay =  _fillArgs_delayMicros args
-    disableIndexesPred =  _fillArgs_disableIndexes args
     gi = mkGenesisInfo $ _env_nodeInfo env
     logg = _env_logger env
     createRanges cid (low, high)
@@ -92,30 +87,8 @@ gapsCut env args cutBS = do
       headersBetween env range >>= \case
         Left e -> logger Error $ fromString $ printf "ApiError for range %s: %s" (show range) (show e)
         Right [] -> logger Error $ fromString $ printf "headersBetween: %s" $ show range
-        Right hs -> writeBlocks env pool disableIndexesPred count hs
+        Right hs -> writeBlocks env pool count hs
       maybe mempty threadDelay delay
-
-listIndexes :: P.Pool Connection -> LogFunctionIO Text -> IO [(String, String)]
-listIndexes pool logger = P.withResource pool $ \conn -> do
-    res <- query_ conn qry
-    forM_ res $ \(_,name) -> do
-      logger Debug "index name"
-      logger Debug $ fromString name
-    return res
-  where
-    qry =
-      "SELECT tablename, indexname FROM pg_indexes WHERE schemaname='public';"
-
-dropIndexes :: P.Pool Connection -> [(String, String)] -> IO ()
-dropIndexes pool indexinfos = forM_ indexinfos $ \(tablename, indexname) -> P.withResource pool $ \conn ->
-  execute_ conn $ Query $ fromString $ printf "ALTER TABLE %s DROP CONSTRAINT %s CASCADE;" tablename indexname
-
-dropExtensions :: P.Pool Connection -> IO ()
-dropExtensions pool = P.withResource pool $ \conn ->
-    mapM_ (execute_ conn . Query) stmts
-  where
-    stmts = map ("DROP EXTENSION " <>) ["btree_gin;"]
-
 
 dedupeMinerKeysTable :: P.Pool Connection -> LogFunctionIO Text -> IO ()
 dedupeMinerKeysTable pool logger = do
@@ -147,15 +120,6 @@ dedupeTables pool logger = do
   -- events, transactions, blocks
   dedupeMinerKeysTable pool logger
   dedupeSignersTable pool logger
-
-withDroppedIndexes :: P.Pool Connection -> LogFunctionIO Text -> IO a -> IO a
-withDroppedIndexes pool logger action = do
-    indexInfos <- listIndexes pool logger
-    fmap fst $ generalBracket (dropIndexes pool indexInfos >> dropExtensions pool) release (const action)
-  where
-    release _ = \case
-      ExitCaseSuccess _ -> dedupeTables pool logger
-      _ -> return ()
 
 getBlockGaps :: Env -> M.Map Int64 (Maybe Int64) -> IO (M.Map Int64 [(Int64,Int64)])
 getBlockGaps env existingMinHeights = withDbDebug env Debug $ do

--- a/haskell-src/exec/Chainweb/Server.hs
+++ b/haskell-src/exec/Chainweb/Server.hs
@@ -257,7 +257,7 @@ scheduledUpdates env pool ssRef runFill fillDelay = forever $ do
 
     when runFill $ do
       logg Info "Filling missing blocks"
-      gaps env (FillArgs fillDelay False)
+      gaps env (FillArgs fillDelay)
       logg Info "Fill finished"
   where
     micros = 1000000

--- a/haskell-src/exec/Chainweb/Worker.hs
+++ b/haskell-src/exec/Chainweb/Worker.hs
@@ -41,7 +41,7 @@ import           Data.Tuple.Strict (T2(..))
 import           Database.Beam hiding (insert)
 import           Database.Beam.Backend.SQL.BeamExtensions
 import           Database.Beam.Postgres
-import           Database.Beam.Postgres.Full (insert, onConflictDefault, onConflict)
+import           Database.Beam.Postgres.Full (insert, onConflict)
 import           Database.PostgreSQL.Simple.Transaction (withTransaction,withSavepoint)
 import           System.Logger hiding (logg)
 ---

--- a/haskell-src/exec/Chainweb/Worker.hs
+++ b/haskell-src/exec/Chainweb/Worker.hs
@@ -82,39 +82,34 @@ writes pool b ks ts es ss tf = P.withResource pool $ \c -> withTransaction c $ d
         --   (unDbHash $ _block_hash b)
         --   (map (const '.') ts)
 
-batchWrites :: P.Pool Connection -> Bool -> [Block] -> [[T.Text]] -> [[Transaction]] -> [[Event]] -> [[Signer]] -> [[Transfer]] -> IO ()
-batchWrites pool indexesDisabled bs kss tss ess sss tfs = P.withResource pool $ \c -> withTransaction c $ do
+batchWrites :: P.Pool Connection -> [Block] -> [[T.Text]] -> [[Transaction]] -> [[Event]] -> [[Signer]] -> [[Transfer]] -> IO ()
+batchWrites pool bs kss tss ess sss tfs = P.withResource pool $ \c -> withTransaction c $ do
     runBeamPostgres c $ do
       -- Write the Blocks if unique
       runInsert
         $ insert (_cddb_blocks database) (insertValues bs)
-        $ actionOnConflict $ onConflict (conflictingFields primaryKey) onConflictDoNothing
+        $ onConflict (conflictingFields primaryKey) onConflictDoNothing
       -- Write Pub Key many-to-many relationships if unique --
       runInsert
         $ insert (_cddb_minerkeys database) (insertValues $ concat $ zipWith (\b ks -> map (MinerKey (pk b)) ks) bs kss)
-        $ actionOnConflict $ onConflict (conflictingFields primaryKey) onConflictDoNothing
+        $ onConflict (conflictingFields primaryKey) onConflictDoNothing
 
     withSavepoint c $ do
       runBeamPostgres c $ do
         -- Write the TXs if unique
         runInsert
           $ insert (_cddb_transactions database) (insertValues $ concat tss)
-          $ actionOnConflict $ onConflict (conflictingFields primaryKey) onConflictDoNothing
+          $ onConflict (conflictingFields primaryKey) onConflictDoNothing
 
         runInsert
           $ insert (_cddb_events database) (insertValues $ concat ess)
-          $ actionOnConflict $ onConflict (conflictingFields primaryKey) onConflictDoNothing
+          $ onConflict (conflictingFields primaryKey) onConflictDoNothing
         runInsert
           $ insert (_cddb_signers database) (insertValues $ concat sss)
-          $ actionOnConflict $ onConflict (conflictingFields primaryKey) onConflictDoNothing
+          $ onConflict (conflictingFields primaryKey) onConflictDoNothing
         runInsert
           $ insert (_cddb_transfers database) (insertValues $ concat tfs)
-          $ actionOnConflict $ onConflict (conflictingFields primaryKey) onConflictDoNothing
-  where
-    {- the type system won't allow me to simply inline the "other" expression -}
-    actionOnConflict other = if indexesDisabled
-      then onConflictDefault -- There shouldn't be any constraints on any tables, so this SHOULD be no-op
-      else other
+          $ onConflict (conflictingFields primaryKey) onConflictDoNothing
 
 
 asPow :: BlockHeader -> PowHeader
@@ -148,8 +143,8 @@ writeBlock env pool count bh = do
     policy :: RetryPolicyM IO
     policy = exponentialBackoff 250_000 <> limitRetries 3
 
-writeBlocks :: Env -> P.Pool Connection -> Bool -> IORef Int -> [BlockHeader] -> IO ()
-writeBlocks env pool disableIndexesPred count bhs = do
+writeBlocks :: Env -> P.Pool Connection -> IORef Int -> [BlockHeader] -> IO ()
+writeBlocks env pool count bhs = do
     iforM_ blocksByChainId $ \chain (Sum numWrites, bhs') -> do
       let ff bh = (hashToDbHash $ _blockHeader_payloadHash bh, _blockHeader_hash bh)
       retrying policy check (const $ payloadWithOutputsBatch env chain (M.fromList (ff <$> bhs')) id) >>= \case
@@ -171,7 +166,7 @@ writeBlocks env pool disableIndexesPred count bhs = do
               err = printf "writeBlocks failed because we don't know how to work this version %s" version
           withEventsMinHeight version err $ \evMinHeight -> do
               let !tfs = M.intersectionWith (\pl bh -> mkTransferRows (fromIntegral $ _blockHeader_height bh) (_blockHeader_chainId bh) (DbHash $ hashB64U $ _blockHeader_hash bh) (posixSecondsToUTCTime $ _blockHeader_creationTime bh) pl evMinHeight) pls (makeBlockMap bhs')
-              batchWrites pool disableIndexesPred (M.elems bs) (M.elems kss) (M.elems tss) (M.elems ess) (M.elems sss) (M.elems tfs)
+              batchWrites pool (M.elems bs) (M.elems kss) (M.elems tss) (M.elems ess) (M.elems sss) (M.elems tfs)
               atomicModifyIORef' count (\n -> (n + numWrites, ()))
   where
 

--- a/haskell-src/exec/Main.hs
+++ b/haskell-src/exec/Main.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Main where
 
@@ -10,7 +12,10 @@ import           Chainweb.Api.ChainId (ChainId(..))
 import           Chainweb.Api.NodeInfo
 import           Chainweb.Backfill (backfill)
 import           Chainweb.BackfillTransfers (backfillTransfersCut)
-import           ChainwebDb.Database (initializeTables)
+import           ChainwebDb.Database (checkTables)
+import           ChainwebDb.Migration (MigrationAction(..))
+import qualified ChainwebDb.Migration as Mg
+
 import           ChainwebData.Env
 import           Chainweb.FillEvents (fillEvents)
 import           Chainweb.Gaps
@@ -20,13 +25,15 @@ import           Chainweb.RichList (richList)
 import           Chainweb.Server (apiServer)
 import           Chainweb.Single (single)
 import           Control.Lens
-import           Control.Monad (unless,void)
+import           Control.Monad (void)
 import           Data.Bifunctor
+import qualified Data.ByteString as BS
+import           Data.FileEmbed
 import qualified Data.Pool as P
 import           Data.String
 import           Data.Text (Text)
 import           Database.PostgreSQL.Simple
-import qualified Database.PostgreSQL.Simple.Migration as Mg
+import qualified Database.PostgreSQL.Simple.Types as PG
 import           Network.Connection hiding (Connection)
 import           Network.HTTP.Client hiding (withConnection)
 import           Network.HTTP.Client.TLS
@@ -46,8 +53,8 @@ main = do
     withLogger (config (getLevel args)) backend $ \logger -> do
       let logg = loggerFunIO logger
       case args of
-        MigrateOnly pgc _ -> withPool pgc $ \pool ->
-          runMigrations pool logg RunMigration False
+        MigrateOnly pgc _ mbMigFolder -> withPool pgc $ \pool ->
+          runMigrations pool logg RunMigrations mbMigFolder
         RichListArgs (NodeDbPath mfp) _ version -> do
           fp <- case mfp of
             Nothing -> do
@@ -59,12 +66,12 @@ main = do
               logg Info $ "Constructing rich list using given db-path: " <> fromString fp
               return fp
           richList logg fp version
-        Args c pgc us u _ ms -> do
+        Args c pgc us u _ ms mbMigFolder -> do
           logg Info $ "Using database: " <> fromString (show pgc)
           logg Info $ "Service API: " <> fromString (showUrlScheme us)
           logg Info $ "P2P API: " <> fromString (showUrlScheme (UrlScheme Https u))
           withCWDPool pgc $ \pool -> do
-            runMigrations pool logg ms (isIndexedDisabled c)
+            runMigrations pool logg ms mbMigFolder
             let mgrSettings = mkManagerSettings (TLSSettingsSimple True False False) Nothing
             m <- newManager mgrSettings
             getNodeInfo m us >>= \case
@@ -89,126 +96,58 @@ main = do
     config level = defaultLoggerConfig
       & loggerConfigThreshold .~ level
     backendConfig = defaultHandleBackendConfig
-    isIndexedDisabled = \case
-      Fill (FillArgs _ p) -> p
-      _ -> False
     getLevel = \case
-      Args _ _ _ _ level _ -> level
+      Args _ _ _ _ level _ _ -> level
       RichListArgs _ level _ -> level
-      MigrateOnly _ level -> level
+      MigrateOnly _ level _ -> level
+
+migrationFiles :: [(FilePath, BS.ByteString)]
+migrationFiles = $(embedDir "db-schema/migrations")
+
+initSql :: BS.ByteString
+initSql = $(embedFile "db-schema/init.sql")
 
 runMigrations ::
-  P.Pool Connection -> LogFunctionIO Text -> MigrateStatus -> Bool -> IO ()
-runMigrations pool logg ms indexesDisabled = do
-  P.withResource pool $ \conn ->
-    unless indexesDisabled $ do
-      initializeTables logg ms conn
-      addTransactionsHeightIndex logg conn
-      addEventsHeightChainIdIdxIndex logg conn
-      addEventsHeightNameParamsIndex logg conn
-      addFromAccountsIndex logg conn
-      addToAccountsIndex logg conn
-      addTransactionsRequestKeyIndex logg conn
-      addEventsRequestKeyIndex logg conn
-      initializePGSimpleMigrations logg conn
+  P.Pool Connection ->
+  LogFunctionIO Text ->
+  Mg.MigrationAction ->
+  Maybe MigrationsFolder ->
+  IO ()
+runMigrations pool logg migAction mbMigFolder = do
+
+  P.withResource pool $ \conn -> do
+    query_ conn "SELECT to_regclass('blocks') :: text" >>= \case
+      [Only (Just ("blocks" :: Text))] -> do
+        logg Debug "blocks table exists, checking if migration initialization has been performed"
+        query_ conn "SELECT to_regclass('schema_migrations') :: text" >>= \case
+          [Only (Just ("schema_migrations" :: Text))] -> do
+            logg Debug "schema_migrations table exists"
+          _ -> do
+            logg Error "schema_migrations table does not exist"
+            logg Error "The chainweb-data database seems to be created by a chainweb-data version \
+                       \prior to the transition to the script-based migration system. Please run \
+                       \the migration transition release (2.1.0) to migrate your database to the \
+                       \transition state. See https://github.com/kadena-io/chainweb-data/releases/tag/v2.1.0"
+            exitFailure
+      _ -> do
+        logg Info "blocks table does not exist, running init.sql to initialize an empty database"
+        void $ execute_ conn (PG.Query initSql)
+
+  files <- case mbMigFolder of
+    Just migFolder -> getDir migFolder
+    Nothing -> return migrationFiles
+
+  let steps = map (uncurry Mg.MigrationStep) files
+
+  Mg.runMigrations migAction steps pool logg
+
+  P.withResource pool $ \conn -> do
+    let isFatalDiffs = case migAction of
+          RunMigrations -> True
+          CheckMigrations -> True
+          PrintMigrations -> False
+    checkTables logg isFatalDiffs conn
   logg Info "DB Tables Initialized"
-
-
-data IndexCreationInfo = IndexCreationInfo
-  {
-    message :: Text
-  , statement :: Query
-  }
-
-addIndex :: IndexCreationInfo -> LogFunctionIO Text -> Connection -> IO ()
-addIndex (IndexCreationInfo m s) logg conn = do
-  logg Info m
-  void $ execute_ conn s
-
-addTransactionsHeightIndex :: LogFunctionIO Text -> Connection -> IO ()
-addTransactionsHeightIndex =
-  addIndex $
-   IndexCreationInfo
-    {
-      message = "Adding height index on transactions table"
-    , statement = "CREATE INDEX IF NOT EXISTS transactions_height_idx ON transactions(height);"
-    }
-
-addEventsHeightChainIdIdxIndex :: LogFunctionIO Text -> Connection -> IO ()
-addEventsHeightChainIdIdxIndex =
-  addIndex $
-    IndexCreationInfo
-    {
-      message = "Adding (height, chainid, idx) index on events table"
-    , statement = "CREATE INDEX IF NOT EXISTS events_height_chainid_idx ON events(height DESC, chainid ASC, idx ASC);"
-    }
-
--- this is roughly "events_height_name_expr_expr1_idx" btree (height, name,
--- (params ->> 0), (params ->> 1)) WHERE name::text = 'TRANSFER'::text
-
-addEventsHeightNameParamsIndex :: LogFunctionIO Text -> Connection -> IO ()
-addEventsHeightNameParamsIndex =
-  addIndex $
-    IndexCreationInfo
-    {
-      message = "Adding \"(height,name,(params ->> 0),(params ->> 1)) WHERE name = 'TRANSFER'\" index"
-    , statement = "CREATE INDEX IF NOT EXISTS events_height_name_expr_expr1_idx ON events (height desc, name, (params ->> 0), (params ->> 1)) WHERE name = 'TRANSFER';"
-    }
-
-addEventsModuleNameIndex :: LogFunctionIO Text -> Connection -> IO ()
-addEventsModuleNameIndex =
-  addIndex $
-    IndexCreationInfo
-    {
-      message = "Adding \"(height desc, chainid, module)\" index"
-    , statement = "CREATE INDEX IF NOT EXISTS events_height_chainid_module ON events (height DESC, chainid, module);"
-    }
-
-addFromAccountsIndex :: LogFunctionIO Text -> Connection -> IO ()
-addFromAccountsIndex =
-  addIndex
-    IndexCreationInfo
-    {
-      message = "Adding \"(from_acct, height desc, idx)\" index on transfers table"
-    , statement = "CREATE INDEX IF NOT EXISTS transfers_from_acct_height_idx ON transfers (from_acct, height desc, idx);"
-    }
-
-addToAccountsIndex :: LogFunctionIO Text -> Connection -> IO ()
-addToAccountsIndex =
-  addIndex
-    IndexCreationInfo
-    {
-      message = "Adding \"(to_acct, height desc,idx)\" index on transfers table"
-    , statement = "CREATE INDEX IF NOT EXISTS transfers_to_acct_height_idx_idx ON transfers (to_acct, height desc, idx);"
-    }
-
-addTransactionsRequestKeyIndex :: LogFunctionIO Text -> Connection -> IO ()
-addTransactionsRequestKeyIndex =
-  addIndex
-    IndexCreationInfo
-    {
-      message = "Adding \"(requestkey)\" index on transactions table"
-    , statement = "CREATE INDEX IF NOT EXISTS transactions_requestkey_idx ON transactions (requestkey);"
-    }
-
-addEventsRequestKeyIndex :: LogFunctionIO Text -> Connection -> IO ()
-addEventsRequestKeyIndex =
-  addIndex
-    IndexCreationInfo
-    {
-      message = "Adding \"(requestkey)\" index on events table"
-    , statement = "CREATE INDEX IF NOT EXISTS events_requestkey_idx ON events (requestkey);"
-    }
-
-initializePGSimpleMigrations :: LogFunctionIO Text -> Connection -> IO ()
-initializePGSimpleMigrations logg conn = do
-  logg Info "Initializing the incremental migrations table"
-  Mg.runMigration (Mg.MigrationContext Mg.MigrationInitialization False conn) >>= \case
-    Mg.MigrationError err -> do
-      let msg = "Error initializing migrations: " ++ err
-      logg Error $ fromString msg
-      die msg
-    Mg.MigrationSuccess -> logg Info "Initialized migrations"
 
 {-
 λ> :main single --chain 2 --height 1487570 --service-host api.chainweb.com --p2p-host us-e3.chainweb.com --dbname chainweb-data --service-port 443 --service-https

--- a/haskell-src/lib/ChainwebDb/Migration.hs
+++ b/haskell-src/lib/ChainwebDb/Migration.hs
@@ -7,6 +7,7 @@ import BasePrelude (exitFailure)
 import Control.Monad
 
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as B64
 import qualified Data.Map as Map
 import qualified Data.Pool as P
 import qualified Data.Text as T
@@ -84,7 +85,7 @@ matchSteps stepsIn existingIn = do
       unless (thisName == name) $ Left
         $ "Steps out of order: Wanted step " <> show thisName
        <> " but found step " <> show name
-      let wantedChecksum = MD5.hash $ msBody ms
+      let wantedChecksum = B64.encode $ MD5.hash $ msBody ms
           foundChecksum = Mg.schemaMigrationChecksum sm
       unless (wantedChecksum == foundChecksum) $ Left
         $ "Checksum mismatch: Wanted step " <> show thisName

--- a/haskell-src/lib/ChainwebDb/Migration.hs
+++ b/haskell-src/lib/ChainwebDb/Migration.hs
@@ -66,8 +66,8 @@ matchSteps = matchRecursive Nothing
       (thisOrder, thisName) <- parseScriptName $ msName ms
       forM_ mbPrevOrder $ \prevOrder -> do
         unless (prevOrder < thisOrder) $ Left $ "Steps out of order: " <> thisName
-      rest <- case existing of
-        [] -> return []
+      case existing of
+        [] -> (ms:) <$> matchRecursive (Just thisOrder) steps []
         (sm:rest) -> do
           (order, name) <- parseScriptName $ T.unpack $ T.decodeUtf8 $ Mg.schemaMigrationName sm
           unless (thisOrder == order) $ Left
@@ -83,8 +83,7 @@ matchSteps = matchRecursive Nothing
             $ "Checksum mismatch: Wanted step " <> show thisName
            <> " with checksum " <> show wantedChecksum <> " but found step " <> show name
            <> " with checksum " <> show foundChecksum
-          return rest
-      matchRecursive (Just thisOrder) steps rest
+          matchRecursive (Just thisOrder) steps rest
 
 data MigrationAction
   = RunMigrations

--- a/haskell-src/lib/ChainwebDb/Migration.hs
+++ b/haskell-src/lib/ChainwebDb/Migration.hs
@@ -1,0 +1,126 @@
+module ChainwebDb.Migration where
+
+import qualified Crypto.Hash.MD5 as MD5 (hash)
+
+import BasePrelude (exitFailure)
+
+import Control.Monad
+
+import qualified Data.ByteString as BS
+import qualified Data.Pool as P
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+
+import Database.PostgreSQL.Simple
+import qualified Database.PostgreSQL.Simple.Migration as Mg
+
+import Safe (readMay)
+import System.Logger hiding (logg)
+
+newtype MigrationOrder = MigrationOrder [Int] deriving (Eq, Ord, Show)
+
+type StepName = String
+
+data MigrationStep = MigrationStep
+  { msName :: Mg.ScriptName
+  , msBody :: BS.ByteString
+  }
+
+-- | Parse a ScriptName in the format "1.2.3_step_name" into a MigrationOrder
+-- and a StepName.
+parseScriptName :: Mg.ScriptName -> Either String (MigrationOrder, StepName)
+parseScriptName fullName = do
+  (orderStr, name) <- case break (== '_') fullName of
+    (_, "") -> Left $ "Could not find _ in " <> fullName
+    (a, _:b) -> Right (a, b)
+
+  order <- parseOrder orderStr
+  return (MigrationOrder order, name)
+  where
+    parseOrder :: String -> Either String [Int]
+    parseOrder = mapM readInt . splitOn '.'
+    readInt :: String -> Either String Int
+    readInt s = case readMay s of
+      Just i -> Right i
+      Nothing -> Left $ "Could not parse int from " <> s
+    splitOn :: Char -> String -> [String]
+    splitOn c s = case break (== c) s of
+      (a, "") -> [a]
+      (a, _:b) -> a : splitOn c b
+
+-- Given a list of steps to execute and a list of steps that have already been
+-- executed check that the sequence of steps satisfies the following:
+-- 1. The steps that have been executed are a prefix of the steps to execute
+-- 2. The steps to execute are in order
+-- 3. The checksums of the steps to execute match the checksums of the steps
+matchSteps ::
+  [MigrationStep] ->
+  [Mg.SchemaMigration] ->
+  Either String [MigrationStep]
+matchSteps = matchRecursive Nothing
+  where
+    matchRecursive _ [] [] = Right []
+    matchRecursive _ [] (sm:_) = Left $
+      "Extra steps in existing migrations: " <> show (Mg.schemaMigrationName sm) <> "..."
+    matchRecursive mbPrevOrder (ms:steps) existing = do
+      (thisOrder, thisName) <- parseScriptName $ msName ms
+      forM_ mbPrevOrder $ \prevOrder -> do
+        unless (prevOrder < thisOrder) $ Left $ "Steps out of order: " <> thisName
+      rest <- case existing of
+        [] -> return []
+        (sm:rest) -> do
+          (order, name) <- parseScriptName $ T.unpack $ T.decodeUtf8 $ Mg.schemaMigrationName sm
+          unless (thisOrder == order) $ Left
+            $ "Steps out of order: Wanted step " <> show thisName
+           <> " has order " <> show thisOrder <> " but found step " <> show name
+           <> " with order " <> show order
+          unless (thisName == name) $ Left
+            $ "Steps out of order: Wanted step " <> show thisName
+           <> " but found step " <> show name
+          let wantedChecksum = MD5.hash $ msBody ms
+              foundChecksum = Mg.schemaMigrationChecksum sm
+          unless (wantedChecksum == foundChecksum) $ Left
+            $ "Checksum mismatch: Wanted step " <> show thisName
+           <> " with checksum " <> show wantedChecksum <> " but found step " <> show name
+           <> " with checksum " <> show foundChecksum
+          return rest
+      matchRecursive (Just thisOrder) steps rest
+
+data MigrationAction
+  = RunMigrations
+  | CheckMigrations
+  | PrintMigrations
+  deriving (Eq,Ord,Show,Read)
+
+runMigrations ::
+  MigrationAction ->
+  [MigrationStep] ->
+  P.Pool Connection ->
+  LogFunctionIO T.Text ->
+  IO ()
+runMigrations act steps pool logg = P.withResource pool $ \c -> withTransaction c $ do
+  existing <- Mg.getMigrations c
+  case matchSteps steps existing of
+    Left err -> do
+      let errLog = flip logg $ "Migration error: " <> T.pack err
+      case act of
+        RunMigrations -> errLog Error >> exitFailure
+        CheckMigrations -> errLog Error >> exitFailure
+        PrintMigrations -> errLog Info
+    Right [] ->
+      logg Info "No migrations to run"
+    Right steps' -> case act of
+      RunMigrations -> forM_ steps' $ \ms -> do
+        logg Info $ "Running migration: " <> T.pack (msName ms)
+        logg Debug $ "Migration body: " <> T.decodeUtf8 (msBody ms)
+        Mg.runMigrations False c [Mg.MigrationScript (msName ms) (msBody ms)]
+      CheckMigrations -> missingMigrations True
+      PrintMigrations -> missingMigrations False
+      where
+        missingMigrations isFatal = do
+          let errLog = flip logg
+                $ "Missing migration steps: "
+               <> T.intercalate ", " (T.pack . msName <$> steps')
+          if isFatal
+          then errLog Error >> exitFailure
+          else errLog Info


### PR DESCRIPTION
This PR implements the second and last step of the transition to script based migrations (#101).

After this PR, new CW-D database migrations can be implemented by creating new scripts in the `haskell-src/db-schema/migrations` folder. The scripts in that folder must be named as `1.2.3.4_somename.sql`. This file names correspond to the version components `[1,2,3,4]` along with the step name `somename.sql`. The version components can contain an arbitrary number of elements, so `1.2.3_othername.sql` is also valid.

The migration logic implemented by this PR aims to be fairly conservative in that it expects the existing migrations to be a perfect prefix of the incoming migrations with the correct order. The order of the migrations are defined by the version components. The condition that the existing migrations need to be a prefix all the desired migrations means that once a set of migrations are run, we can only append new migrations and those migrations have to have version components that are bigger than the existing migrations. 

The reason why we're being conservative like this is to avoid very subtle issues that occasionally arise due to migrations running in different orders in different deployments.

It's also worth noting that the `--migrations-folder` introduced by this PR is optional and when that argument is not provided, CW-D uses the set of migrations that get embedded into the binary from the repository during compilation. The purpose is to avoid increasing the operational complexity of running CW-D from a compiled binary. The set of migrations associated with a CW-D release are tightly coupled with the Haskell code that comes with it anyway.

Another point worth noting is that this migrations workflow also allows CW-D operators to interleave their own migrations with the official migrations that come with CW-D. If the operator of a particular CW-D node wants to include additional migrations, they can do so by maintaining a `migrations` folder of their own and including the official CW-D migrations side by side with their own migrations. In this setup, they need to name their own migration scripts to have version numbers that are compatible with this migration workflow.

Resolves #101