### PR TITLE
Avoid checkTables errors due to unexpected DB objects

### DIFF
--- a/haskell-src/lib/ChainwebDb/Database.hs
+++ b/haskell-src/lib/ChainwebDb/Database.hs
@@ -152,7 +152,10 @@ annotatedDb = BA.defaultAnnotatedDbSettings database
 calcCWMigrationSteps :: Connection -> IO BA.Diff
 calcCWMigrationSteps conn = BA.calcMigrationSteps annotatedDb conn <&> \eiSteps ->
   flip fmap eiSteps $ filter $ \step -> case BA._editAction $ fst $ BA.unPriority step of
-    BA.TableRemoved _ -> False
+    BA.TableRemoved{} -> False
+    BA.ColumnRemoved{} -> False
+    BA.EnumTypeRemoved{} -> False
+    BA.SequenceRemoved{} -> False
     _ -> True
 
 showMigration :: Connection -> IO ()


### PR DESCRIPTION
We've recently (#101) moved away from `beam-automigrate` for handling our DB migrations, but we've mostly kept the DB schema compatibility checks that come with it as a safety measure. 

One of the important benefits of #101 was the leniency it brought towards external DB schema manipulations that might be useful to `chainweb-data` operators. To that end, our DB migration check was already ignoring `TableRemoved` diffs so that new tables can be created in the DB without causing issues.

This PR extends that leniency towards other types of objects `beam-automigrate` looks for. Their omission was an oversight.