### PR TITLE
Add separate subcommand for critical schema checks

### DIFF
--- a/haskell-src/lib/ChainwebData/Env.hs
+++ b/haskell-src/lib/ChainwebData/Env.hs
@@ -21,6 +21,7 @@ module ChainwebData.Env
   , FillArgs(..)
   , envP
   , migrateOnlyP
+  , checkSchemaP
   , richListP
   , NodeDbPath(..)
   , progress
@@ -69,6 +70,7 @@ data Args
   | RichListArgs NodeDbPath LogLevel ChainwebVersion
     -- ^ arguments for the Richlist command
   | MigrateOnly Connect LogLevel (Maybe MigrationsFolder)
+  | CheckSchema Connect LogLevel
   deriving (Show)
 
 data Env = Env
@@ -274,6 +276,18 @@ migrateOnlyP = hsubparser
       <$> connectP
       <*> logLevelParser
       <*> migrationsFolderParser
+
+checkSchemaP :: Parser Args
+checkSchemaP = hsubparser
+  ( command "check-schema"
+    ( info opts $ progDesc
+        "Check the DB schema against the ORM definitions"
+    )
+  )
+  where
+    opts = CheckSchema
+      <$> connectP
+      <*> logLevelParser
 
 richListP :: Parser Args
 richListP = hsubparser

--- a/haskell-src/lib/ChainwebDb/Database.hs
+++ b/haskell-src/lib/ChainwebDb/Database.hs
@@ -175,8 +175,8 @@ checkTables logg fatalDiffs conn = do
       Right [] -> logg Info "The DB schema is compatible with the ORM definition."
       Right _ -> do
         let logLevel = if fatalDiffs then Error else Info
-        logg logLevel "The DB schema is not compatible with the ORM definition."
-        logg logLevel "The following changes are needed:"
+        logg logLevel "Unexpected differences between the ORM definition and the DB schema."
+        logg logLevel "The following changes would align them:"
         showMigration conn
         logg logLevel "These changes are probably due to manual changes to the DB schema, if not please report this as a bug."
         when fatalDiffs $ do


### PR DESCRIPTION
This PR adds a new `check-schema` subcommand to `chainweb-data` to make the intent of checking the ORM definitions against the DB schema explicit. After this PR, running `chainweb-data check-schema` is the only case where the process might fail due to unexpected schema differences. Other ways of running `chainweb-data` still compare the DB schema against the ORM definitions, but they only print `Info` messages and keep going.

Resolves #145 