### PR TITLE
Separate ETL and HTTP services

### DIFF
--- a/haskell-src/exec/Main.hs
+++ b/haskell-src/exec/Main.hs
@@ -89,7 +89,7 @@ main = do
                       Fill as -> gaps env as
                       Single cid h -> single env cid h
                       FillEvents as et -> fillEvents env as et
-                      Server serverEnv -> apiServer env serverEnv
+                      Worker workerEnv -> apiServer env workerEnv
         CheckSchema pgc _ -> withCWDPool pgc $ \pool -> do
           P.withResource pool $ checkTables logg True
 

--- a/haskell-src/exec/Main.hs
+++ b/haskell-src/exec/Main.hs
@@ -26,7 +26,7 @@ import           Chainweb.Server (apiServer, scheduledUpdates, retryingListener)
 import           Chainweb.Single (single)
 import           Control.Concurrent (forkIO)
 import           Control.Lens
-import           Control.Monad (forM_, void)
+import           Control.Monad (forM_, when, void)
 import           Data.Bifunctor
 import qualified Data.ByteString as BS
 import           Data.FileEmbed
@@ -92,10 +92,9 @@ main = do
                       FillEvents as et -> fillEvents env as et
                       Worker workerEnv -> do
                         forM_ (getETLEnv workerEnv) $ \(ETLEnv runFill fillDelay) -> do
-                            logg Info $ "Starting scheduled updates with delay " <> fromString (show fillDelay)
-                            _ <- forkIO $ scheduledUpdates env pool runFill fillDelay
+                            void $ forkIO $ scheduledUpdates env pool runFill fillDelay
                             logg Info "Starting retrying listener"
-                            forkIO $ retryingListener env
+                            void $ forkIO $ retryingListener env
                         forM_ (getHTTPEnv workerEnv) $ apiServer env
         CheckSchema pgc _ -> withCWDPool pgc $ \pool -> do
           P.withResource pool $ checkTables logg True

--- a/haskell-src/lib/ChainwebData/Env.hs
+++ b/haskell-src/lib/ChainwebData/Env.hs
@@ -12,7 +12,6 @@ module ChainwebData.Env
   , ETLEnv (..)
   , getHTTPEnv
   , getETLEnv
-  , httpP
   , Connect(..), withPoolInit, withPool, withCWDPool
   , Scheme(..)
   , toServantScheme

--- a/haskell-src/lib/ChainwebData/Env.hs
+++ b/haskell-src/lib/ChainwebData/Env.hs
@@ -392,10 +392,7 @@ singleP = Single
   <*> option auto (long "height" <> metavar "INT")
 
 serverP :: Parser ServerEnv
-serverP = fullP <|> httpP <|> etlP
-
-fullP :: Parser ServerEnv
-fullP = toServerEnv
+serverP = toServerEnv
   <$> option auto (long "port" <> metavar "INT" <> help "Port the server will listen on")
   <*> flag False True (long "run-fill" <> short 'f' <> help "Run fill operation once a day to fill gaps")
   <*> delayP
@@ -451,6 +448,10 @@ commands = hsubparser
        (progDesc "Single Worker - Lookup and write the blocks at a given chain/height"))
   <> command "server" (info (Server <$> serverP)
        (progDesc "Serve the chainweb-data REST API (also does listen)"))
+  <> command "etl" (info (Server <$> etlP)
+       (progDesc "ETL Worker - Fills in missing blocks and listens for new ones"))
+  <> command "http" (info (Server <$> httpP)
+       (progDesc "HTTP Worker - Serves the chainweb-data REST API"))
   <> command "fill-events" (info (FillEvents <$> bfArgsP <*> eventTypeP)
        (progDesc "Event Worker - Fills missing events"))
   <> command "backfill-transfers" (info (BackFillTransfers <$> flag False True (long "disable-indexes" <> help "Delete indexes on transfers table") <*> bfArgsP)

--- a/haskell-src/lib/ChainwebData/Env.hs
+++ b/haskell-src/lib/ChainwebData/Env.hs
@@ -384,13 +384,6 @@ serverP = toServerEnv
       False -> Full (HTTPEnv port  serveSwaggerUi, ETLEnv runFill delay)
       True -> HTTP (HTTPEnv port serveSwaggerUi)
 
-httpP :: Parser ServerEnv
-httpP = toServerEnv
-  <$> option auto (long "port" <> metavar "INT" <> help "Port the server will listen on")
-  <*> flag False True (long "serve-swagger-ui" <> internal)
-  where
-    toServerEnv port serveSwaggerUi = HTTP (HTTPEnv port serveSwaggerUi)
-
 etlP :: Parser (Maybe ETLEnv)
 etlP = optional $ toETLEnv
   <$> flag False True (long "run-fill" <> short 'f' <> help "Run fill operation once a day to fill gaps")

--- a/haskell-src/lib/ChainwebData/Env.hs
+++ b/haskell-src/lib/ChainwebData/Env.hs
@@ -8,15 +8,10 @@ module ChainwebData.Env
   , MigrationsFolder
   , chainStartHeights
   , WorkerEnv(..)
-  , _Full
-  , _HTTP
-  , _ETL
   , HTTPEnv (..)
-  , httpEnv_port
-  , httpEnv_serveSwaggerUi
   , ETLEnv (..)
-  , etlEnv_runFill
-  , etlEnv_fillDelay
+  , getHTTPEnv
+  , getETLEnv
   , Connect(..), withPoolInit, withPool, withCWDPool
   , Scheme(..)
   , toServantScheme
@@ -43,7 +38,6 @@ import           Chainweb.Api.NodeInfo
 import           ChainwebDb.Migration
 import           Control.Concurrent
 import           Control.Exception
-import           Control.Lens
 import           Control.Monad (void)
 import           Data.ByteString (ByteString)
 import           Data.Char (toLower)
@@ -239,19 +233,16 @@ data WorkerEnv = Full FullEnv | HTTP HTTPEnv | ETL ETLEnv
 
 type FullEnv = (HTTPEnv, ETLEnv)
 
-_Full :: Prism' WorkerEnv FullEnv
-_Full = prism' Full $ \case
-  Full x -> Just x
+getHTTPEnv :: WorkerEnv -> Maybe HTTPEnv
+getHTTPEnv = \case
+  HTTP env -> Just env
+  Full (env,_) -> Just env
   _ -> Nothing
 
-_HTTP :: Prism' WorkerEnv HTTPEnv
-_HTTP = prism' HTTP $ \case
-  HTTP x -> Just x
-  _ -> Nothing
-
-_ETL :: Prism' WorkerEnv ETLEnv
-_ETL = prism' ETL $ \case
-  ETL x -> Just x
+getETLEnv :: WorkerEnv -> Maybe ETLEnv
+getETLEnv = \case
+  ETL env -> Just env
+  Full (_,env) -> Just env
   _ -> Nothing
 
 data HTTPEnv = HTTPEnv
@@ -259,22 +250,10 @@ data HTTPEnv = HTTPEnv
  , _httpEnv_serveSwaggerUi :: Bool
  } deriving (Eq,Ord,Show)
 
-httpEnv_port :: Lens' HTTPEnv Int
-httpEnv_port = lens _httpEnv_port $ \x y -> x { _httpEnv_port = y }
-
-httpEnv_serveSwaggerUi :: Lens' HTTPEnv Bool
-httpEnv_serveSwaggerUi = lens _httpEnv_serveSwaggerUi $ \x y -> x { _httpEnv_serveSwaggerUi = y }
-
 data ETLEnv = ETLEnv
  { _etlEnv_runFill :: Bool
  , _etlEnv_fillDelay :: Maybe Int
  } deriving (Eq,Ord,Show)
-
-etlEnv_runFill :: Lens' ETLEnv Bool
-etlEnv_runFill = lens _etlEnv_runFill $ \x y -> x { _etlEnv_runFill = y }
-
-etlEnv_fillDelay :: Lens' ETLEnv (Maybe Int)
-etlEnv_fillDelay = lens _etlEnv_fillDelay $ \x y -> x { _etlEnv_fillDelay = y }
 
 envP :: Parser Args
 envP = Args

--- a/haskell-src/lib/ChainwebData/Env.hs
+++ b/haskell-src/lib/ChainwebData/Env.hs
@@ -377,7 +377,7 @@ serverP = toServerEnv
   <*> delayP
   -- The OpenAPI spec is currently rudimentary and not official so we're hiding this option
   <*> flag False True (long "serve-swagger-ui" <> internal)
-  <*> flag False True (long "no-etl" <> help "Disable ETL")
+  <*> flag False True (long "no-listen" <> help "Disable ETL")
   where
     toServerEnv port runFill delay serveSwaggerUi = \case
       False -> Full (HTTPEnv port  serveSwaggerUi, ETLEnv runFill delay)


### PR DESCRIPTION
In this PR, our goal is to make it possible for an operator to run chainweb-data either as a server or as an
ETL service gathering data from chainweb-node. We will still allow an operator to run chainweb-data performing the aforementioned services simultaneously.