### PR TITLE
Attach signer information to tx(s) endpoints

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,8 +18,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: b3e28d62c622ebda0d84e136ea6c995d5f97e46f
-    --sha256: sha256-8Kclw75I8Jg/NAExfauoPRVJId1wfLGnO2lXXotNPdU=
+    tag: 9a62ce26c5d71343bcad17b4ef0d7c27bb536791
+    --sha256: sha256-qzS6oIJaTzeIHrUnQrV3gBvy5SvWQc8rujxpRvoXC3s=
 
 source-repository-package
     type: git

--- a/haskell-src/db-schema/migrations/2.2.0.1_swap_signers_pkey.sql
+++ b/haskell-src/db-schema/migrations/2.2.0.1_swap_signers_pkey.sql
@@ -1,0 +1,2 @@
+ALTER TABLE signers DROP CONSTRAINT signers_pkey;
+ALTER TABLE cwd.signers ADD CONSTRAINT signers_pkey PRIMARY KEY (requestkey, idx);

--- a/haskell-src/exec/Chainweb/Server.hs
+++ b/haskell-src/exec/Chainweb/Server.hs
@@ -415,7 +415,7 @@ queryTxsByKey logger rk c =
        ev <- all_ (_cddb_events database)
        guard_ (_ev_requestkey ev ==. val_ (RKCB_RequestKey $ DbHash rk))
        return ev
-    dbSigners <- runSelectReturningList $ select $ do
+    dbSigners <- runSelectReturningList $ select $ orderBy_ (asc_ . _signer_idx) $ do
        signer <- all_ (_cddb_signers database)
        guard_ (_signer_requestkey signer ==. val_ (DbHash rk))
        return signer


### PR DESCRIPTION
This PR adds the `_txDetail_signers :: [Signer]` field to the `TxDetail` served by the `GET /txs/tx` and `GET /txs/txs` endpoints.

Additionally:
* It implements the necessary `ToSchema` types for the OAS3 spec.
* Adds a schema migration that swaps the order of the primary key columns of the `signers` table so that the primary key index supports efficient signer lookups.