### PR TITLE
Add sigs field to tx detail responses

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,7 +18,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: 00650534d4b3065342207a732131c88519209177
+    tag: ef2bee367136e298dfb45ea118d122350e7b3bc7
     --sha256: sha256-VQ/JhpZaINeTZHNt7TZ9WaVGIXJEf9bDQ51cSG+auVI=
 
 source-repository-package

--- a/cabal.project
+++ b/cabal.project
@@ -18,8 +18,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: 9a62ce26c5d71343bcad17b4ef0d7c27bb536791
-    --sha256: sha256-qzS6oIJaTzeIHrUnQrV3gBvy5SvWQc8rujxpRvoXC3s=
+    tag: 00650534d4b3065342207a732131c88519209177
+    --sha256: sha256-VQ/JhpZaINeTZHNt7TZ9WaVGIXJEf9bDQ51cSG+auVI=
 
 source-repository-package
     type: git

--- a/haskell-src/lib/ChainwebData/Spec.hs
+++ b/haskell-src/lib/ChainwebData/Spec.hs
@@ -24,6 +24,7 @@ import Data.OpenApi.Schema
 import Servant.OpenApi
 import ChainwebData.Pagination
 import Chainweb.Api.ChainId
+import Chainweb.Api.Sig
 import Chainweb.Api.Signer
 import ChainwebData.TxSummary
 import Data.OpenApi
@@ -99,6 +100,14 @@ instance ToSchema SigCapability where
            , ("args", valueSchema)
            ]
       & required .~ ["name", "args"]
+
+instance ToSchema Sig where
+  declareNamedSchema _ = do
+    textSchema <- declareSchemaRef (Proxy :: Proxy T.Text)
+    return $ NamedSchema (Just "Sig") $ mempty
+      & type_ ?~ OpenApiObject
+      & properties .~ [ ("sig", textSchema) ]
+      & required .~ ["sig"]
 
 instance ToSchema (StringEncoded Scientific) where
   declareNamedSchema _ = pure $ NamedSchema (Just "StringEncodedNumber") $ mempty


### PR DESCRIPTION
This PR is an amendment to #152, where we omitted the `sigs` field by oversight.