### PR TITLE
Update 2.2.0.1_swap_signers_pkey.sql

### DIFF
--- a/haskell-src/db-schema/migrations/2.2.0.1_swap_signers_pkey.sql
+++ b/haskell-src/db-schema/migrations/2.2.0.1_swap_signers_pkey.sql
@@ -1,2 +1,2 @@
 ALTER TABLE signers DROP CONSTRAINT signers_pkey;
-ALTER TABLE cwd.signers ADD CONSTRAINT signers_pkey PRIMARY KEY (requestkey, idx);
+ALTER TABLE signers ADD CONSTRAINT signers_pkey PRIMARY KEY (requestkey, idx);


### PR DESCRIPTION
Remove "cwd" schema prefix to correct migration to close #154.