### PR TITLE
HLS integration fixes for the chainweb-data codebase

### DIFF
--- a/haskell-src/exec/Chainweb/Coins.hs
+++ b/haskell-src/exec/Chainweb/Coins.hs
@@ -37,11 +37,11 @@ import           Text.Read
 -- | Read in the reward csv via TH for deployment purposes.
 --
 rawMinerRewards :: ByteString
-rawMinerRewards = $(embedFile "data/miner_rewards.csv")
+rawMinerRewards = $(makeRelativeToProject "data/miner_rewards.csv" >>= embedFile)
 {-# NOINLINE rawMinerRewards #-}
 
 rawAllocations :: ByteString
-rawAllocations = $(embedFile "data/token_payments.csv")
+rawAllocations = $(makeRelativeToProject "data/token_payments.csv" >>= embedFile)
 
 allocations :: [AllocationEntry]
 allocations = V.toList $ decodeAllocations rawAllocations

--- a/haskell-src/exec/Main.hs
+++ b/haskell-src/exec/Main.hs
@@ -118,10 +118,10 @@ main = do
       CheckSchema _ level -> level
 
 migrationFiles :: [(FilePath, BS.ByteString)]
-migrationFiles = $(embedDir "db-schema/migrations")
+migrationFiles = $(makeRelativeToProject "db-schema/migrations" >>= embedDir)
 
 initSql :: BS.ByteString
-initSql = $(embedFile "db-schema/init.sql")
+initSql = $(makeRelativeToProject "db-schema/init.sql" >>= embedFile)
 
 runMigrations ::
   P.Pool Connection ->

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,5 @@
+cradle:
+  cabal:
+    - path: "haskell-src"
+      component: "lib:chainweb-data"
+


### PR DESCRIPTION
This PR adds a `hie.yaml` to the project and also works around the following HLS bug:

https://github.com/haskell/haskell-language-server/issues/481

That issue is actually related to stack, but seems like the cabal integration is suffering from the same in our case. There are quite a few relative-path related issues open in HLS anyway.

This commit uses the `makeRelativeToProject` function from file-embed ([As suggested by phadej under another issue](https://github.com/commercialhaskell/stack/issues/5421#issuecomment-737110569)) in order to resolve the relative paths in a way that's independent of the build system, working around this long-standing HLS bug.