### PR TITLE
Migrate to hs-nix-infra for the Nix setup

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -40,4 +40,6 @@ jobs:
       run: |
         echo Building the project and its devShell
         nix build .#check --log-lines 500 --show-trace
-        nix build .#recursive --log-lines 500 --show-trace
+
+        echo Build the recursive output
+        nix build .#recursive.allDerivations --log-lines 500 --show-trace

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,10 +19,12 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Nix with caching
-      uses: kadena-io/setup-nix-with-cache/by-root@v3
+      uses: kadena-io/setup-nix-with-cache/by-root@v3.1
       with:
         cache_url: s3://nixcache.chainweb.com?region=us-east-1
         signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
+        additional_experimental_features: recursive-nix
+
 
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v2
@@ -32,9 +34,10 @@ jobs:
         aws-region: us-east-1
 
     - name: Give root user AWS credentials
-      uses: kadena-io/setup-nix-with-cache/copy-root-aws-credentials@v3
+      uses: kadena-io/setup-nix-with-cache/copy-root-aws-credentials@v3.1
 
     - name: Build and cache artifacts
       run: |
         echo Building the project and its devShell
         nix build .#check --log-lines 500 --show-trace
+        nix build .#recursive --log-lines 500 --show-trace

--- a/default.nix
+++ b/default.nix
@@ -29,7 +29,7 @@ let profilingModule = {
       enableLibraryProfiling = enableProfiling;
       enableProfiling = enableProfiling;
     };
-    chainweb-data = pkgs.haskell-nix.project' {
+    project = pkgs.haskell-nix.project' {
 	    src = ./.;
       index-state = "2023-02-01T00:00:00Z";
 	    compiler-nix-name = "ghc8107";
@@ -39,7 +39,7 @@ let profilingModule = {
 	    };
       modules = if enableProfiling then [ profilingModule ] else [];
     };
-    flake = chainweb-data.flake {};
+    flake = project.flake';
     default = flake.packages."chainweb-data:exe:chainweb-data".override (old: {
       inherit dontStrip;
       flags = old.flags // {
@@ -65,5 +65,5 @@ let profilingModule = {
        };
     };
 in {
-  inherit flake default dockerImage;
+  inherit project flake default dockerImage;
 }

--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,7 @@ let inputs = (import (
      ) {
        src =  ./.;
      }).defaultNix.inputs;
+    hs-nix-infra = inputs.hs-nix-infra;
     pkgsDef = import hs-nix-infra.nixpkgs {
       config = hs-nix-infra.haskellNix.config;
       overlays = [ hs-nix-infra.haskellNix.overlay] ;

--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,10 @@ let inputs = (import (
      ) {
        src =  ./.;
      }).defaultNix.inputs;
-    pkgsDef = import inputs.nixpkgs (import inputs.haskellNix {}).nixpkgsArgs;
+    pkgsDef = import hs-nix-infra.nixpkgs {
+      config = hs-nix-infra.haskellNix.config;
+      overlays = [ hs-nix-infra.haskellNix.overlay] ;
+    };
 in
 { pkgs ? pkgsDef
 , dontStrip ? false
@@ -58,7 +61,7 @@ let profilingModule = {
          WorkingDir = "/chainweb-data";
          Volumes = { "/chainweb-data" = {}; };
          Entrypoint = [ "chainweb-data" ];
-       }; 
+       };
     };
 in {
   inherit flake default dockerImage;

--- a/flake.lock
+++ b/flake.lock
@@ -226,11 +226,11 @@
         "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1699959816,
-        "narHash": "sha256-OurMcrf07sCDHBumWm8lorsA9hhiKX5KnVogsxx7bJs=",
+        "lastModified": 1699970998,
+        "narHash": "sha256-NgvBCRIB+lvcxJWMpU8Mulx8PG8s5jtqSR8K/natoTA=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "a38e0b9c37cc67ef27241d33fcc30d01125f12b5",
+        "rev": "a69071dafa3f0d12edf30ecc5a562aee1f7d138d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -17,18 +17,16 @@
       }
     },
     "flake-compat": {
-      "flake": false,
       "locked": {
-        "lastModified": 1672831974,
-        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
-        "owner": "input-output-hk",
+        "lastModified": 1699384378,
+        "narHash": "sha256-jI0nYllONVrNnyOYrvQMIEJQJuNeKnfJo5keRxWMcWs=",
+        "owner": "kadena-io",
         "repo": "flake-compat",
-        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "rev": "6ef9397736efb0f6075188aa3488022d1b85c11d",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "ref": "hkm/gitlab-fix",
+        "owner": "kadena-io",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -49,43 +47,6 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "type": "github"
-      }
-    },
-    "ghc980": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1692910316,
-        "narHash": "sha256-Qv8I3GzzIIN32RTEKI38BW5nO1f7j6Xm+dDeDUyYZWo=",
-        "ref": "ghc-9.8",
-        "rev": "249aa8193e4c5c1ee46ce29b39d2fffa57de7904",
-        "revCount": 61566,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.8",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc99": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1695427505,
-        "narHash": "sha256-j0hXl6uEI+Uwf37z3WLuQZN4S0XqGtiepELv2Gl2aHU=",
-        "ref": "refs/heads/master",
-        "rev": "b8e4fe2318798185228fb5f8214ba2384ac95b4f",
-        "revCount": 61951,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
       }
     },
     "hackage": {
@@ -126,13 +87,22 @@
           "hs-nix-infra",
           "empty"
         ],
-        "flake-compat": "flake-compat",
+        "flake-compat": [
+          "hs-nix-infra",
+          "flake-compat"
+        ],
         "ghc-8.6.5-iohk": [
           "hs-nix-infra",
           "empty"
         ],
-        "ghc980": "ghc980",
-        "ghc99": "ghc99",
+        "ghc980": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "ghc99": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "hackage": [
           "hs-nix-infra",
           "hackage"
@@ -235,16 +205,18 @@
     "hs-nix-infra": {
       "inputs": {
         "empty": "empty",
+        "flake-compat": "flake-compat",
         "hackage": "hackage",
         "haskellNix": "haskellNix",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1699020807,
-        "narHash": "sha256-T/vXF8PXGGnZXNAspFx3yhGFWh4n3a8f1UHlfuHWH1A=",
+        "lastModified": 1699628182,
+        "narHash": "sha256-ESu3Xj4jhcBLN0WdNvxmH5sjRcvrBMlvb7Ja+gnC7wk=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "4e2cc022e56412eef42527f3876bae8c0ad0fe5d",
+        "rev": "320d8cb715e3d32b2b08ff17d7dc7b97c86d6c50",
         "type": "github"
       },
       "original": {
@@ -254,6 +226,22 @@
       }
     },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1669833724,
+        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "type": "github"
+      }
+    },
+    "nixpkgs-rec": {
       "locked": {
         "lastModified": 1669833724,
         "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",

--- a/flake.lock
+++ b/flake.lock
@@ -226,15 +226,16 @@
         "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1699538616,
-        "narHash": "sha256-RVMPCvCeaSVpfzSgcM6yj8tvX8SC9qb8fCb5HEg9qUg=",
+        "lastModified": 1699874720,
+        "narHash": "sha256-pwrhFYDvTas7cTtnNCHyMLQm6wfh76+eLu1LkVwgmQ0=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "3e2e6de968740e42eeaed7224e0465f267e7206d",
+        "rev": "11dda86d5e84c0b99823be340b13890323f51ec2",
         "type": "github"
       },
       "original": {
         "owner": "kadena-io",
+        "ref": "enis/metadata-experiments",
         "repo": "hs-nix-infra",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -226,11 +226,11 @@
         "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1699874720,
-        "narHash": "sha256-pwrhFYDvTas7cTtnNCHyMLQm6wfh76+eLu1LkVwgmQ0=",
+        "lastModified": 1699898255,
+        "narHash": "sha256-+Ywg88IjmmKaxaY6n6DkgLHEco8VTcTTTUEOX4FZ+n4=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "11dda86d5e84c0b99823be340b13890323f51ec2",
+        "rev": "7bb0e680419bea0ebf2a925915cfc06742c51e36",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -226,11 +226,11 @@
         "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1699898255,
-        "narHash": "sha256-+Ywg88IjmmKaxaY6n6DkgLHEco8VTcTTTUEOX4FZ+n4=",
+        "lastModified": 1699956738,
+        "narHash": "sha256-OurMcrf07sCDHBumWm8lorsA9hhiKX5KnVogsxx7bJs=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "7bb0e680419bea0ebf2a925915cfc06742c51e36",
+        "rev": "8c1053765b265a8f13885687f00e094a7a5b76e5",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -31,6 +31,23 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -87,10 +104,7 @@
           "hs-nix-infra",
           "empty"
         ],
-        "flake-compat": [
-          "hs-nix-infra",
-          "flake-compat"
-        ],
+        "flake-compat": "flake-compat_2",
         "ghc-8.6.5-iohk": [
           "hs-nix-infra",
           "empty"
@@ -212,11 +226,11 @@
         "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1699628182,
-        "narHash": "sha256-ESu3Xj4jhcBLN0WdNvxmH5sjRcvrBMlvb7Ja+gnC7wk=",
+        "lastModified": 1699538616,
+        "narHash": "sha256-RVMPCvCeaSVpfzSgcM6yj8tvX8SC9qb8fCb5HEg9qUg=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "320d8cb715e3d32b2b08ff17d7dc7b97c86d6c50",
+        "rev": "3e2e6de968740e42eeaed7224e0465f267e7206d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -226,16 +226,15 @@
         "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1699956738,
+        "lastModified": 1699959816,
         "narHash": "sha256-OurMcrf07sCDHBumWm8lorsA9hhiKX5KnVogsxx7bJs=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "8c1053765b265a8f13885687f00e094a7a5b76e5",
+        "rev": "a38e0b9c37cc67ef27241d33fcc30d01125f12b5",
         "type": "github"
       },
       "original": {
         "owner": "kadena-io",
-        "ref": "enis/metadata-experiments",
         "repo": "hs-nix-infra",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,158 +1,18 @@
 {
   "nodes": {
-    "HTTP": {
+    "empty": {
       "flake": false,
       "locked": {
-        "lastModified": 1451647621,
-        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
-        "owner": "phadej",
-        "repo": "HTTP",
-        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "lastModified": 1683033565,
+        "narHash": "sha256-UZ2dz7/RzJKTw/8uqLu6biAbb3xNk23xUHb5/oAYWsw=",
+        "owner": "kadena-io",
+        "repo": "empty",
+        "rev": "c30c041f692678788a294069c95677774be2dff3",
         "type": "github"
       },
       "original": {
-        "owner": "phadej",
-        "repo": "HTTP",
-        "type": "github"
-      }
-    },
-    "blank": {
-      "locked": {
-        "lastModified": 1625557891,
-        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
-        "owner": "divnix",
-        "repo": "blank",
-        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "blank",
-        "type": "github"
-      }
-    },
-    "cabal-32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-34": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1640353650,
-        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.4",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-36": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641652457,
-        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.6",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cardano-shell": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1608537748,
-        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "type": "github"
-      }
-    },
-    "devshell": {
-      "inputs": {
-        "flake-utils": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1663445644,
-        "narHash": "sha256-+xVlcK60x7VY1vRJbNUEAHi17ZuoQxAIH4S4iUFUGBA=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "e3dc3e21594fe07bdb24bdf1c8657acaa4cb8f66",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "dmerge": {
-      "inputs": {
-        "nixlib": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ],
-        "yants": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "yants"
-        ]
-      },
-      "locked": {
-        "lastModified": 1659548052,
-        "narHash": "sha256-fzI2gp1skGA8mQo/FBFrUAtY0GQkAIAaV/V127TJPyY=",
-        "owner": "divnix",
-        "repo": "data-merge",
-        "rev": "d160d18ce7b1a45b88344aa3f13ed1163954b497",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "data-merge",
+        "owner": "kadena-io",
+        "repo": "empty",
         "type": "github"
       }
     },
@@ -173,29 +33,16 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -204,110 +51,51 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_5": {
-      "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "ghc-8.6.5-iohk": {
+    "ghc980": {
       "flake": false,
       "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
+        "lastModified": 1692910316,
+        "narHash": "sha256-Qv8I3GzzIIN32RTEKI38BW5nO1f7j6Xm+dDeDUyYZWo=",
+        "ref": "ghc-9.8",
+        "rev": "249aa8193e4c5c1ee46ce29b39d2fffa57de7904",
+        "revCount": 61566,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
       },
       "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
-        "type": "github"
+        "ref": "ghc-9.8",
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
       }
     },
-    "gomod2nix": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2",
-        "utils": "utils"
-      },
+    "ghc99": {
+      "flake": false,
       "locked": {
-        "lastModified": 1655245309,
-        "narHash": "sha256-d/YPoQ/vFn1+GTmSdvbSBSTOai61FONxB4+Lt6w/IVI=",
-        "owner": "tweag",
-        "repo": "gomod2nix",
-        "rev": "40d32f82fc60d66402eb0972e6e368aeab3faf58",
-        "type": "github"
+        "lastModified": 1695427505,
+        "narHash": "sha256-j0hXl6uEI+Uwf37z3WLuQZN4S0XqGtiepELv2Gl2aHU=",
+        "ref": "refs/heads/master",
+        "rev": "b8e4fe2318798185228fb5f8214ba2384ac95b4f",
+        "revCount": 61951,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
       },
       "original": {
-        "owner": "tweag",
-        "repo": "gomod2nix",
-        "type": "github"
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
       }
     },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1675211313,
-        "narHash": "sha256-+VJq1EUbeXrd9ph/vN+s5+bdCk2kRbcxpVo4MjbIiSc=",
+        "lastModified": 1696379114,
+        "narHash": "sha256-dtax/ci3JfYvR2lLsvpvC6b3NCoEGZLrDH21/2svTps=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "030f56486a8d0f38f36e0bfbc5aab00db08245e4",
+        "rev": "21eae6f46c91831741496101e541e628aadecd98",
         "type": "github"
       },
       "original": {
@@ -318,38 +106,107 @@
     },
     "haskellNix": {
       "inputs": {
-        "HTTP": "HTTP",
-        "cabal-32": "cabal-32",
-        "cabal-34": "cabal-34",
-        "cabal-36": "cabal-36",
-        "cardano-shell": "cardano-shell",
+        "HTTP": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cabal-32": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cabal-34": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cabal-36": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cardano-shell": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_2",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "hackage": "hackage",
-        "hpc-coveralls": "hpc-coveralls",
-        "hydra": "hydra",
-        "iserv-proxy": "iserv-proxy",
+        "ghc-8.6.5-iohk": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "ghc980": "ghc980",
+        "ghc99": "ghc99",
+        "hackage": [
+          "hs-nix-infra",
+          "hackage"
+        ],
+        "hls-1.10": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hls-2.0": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hls-2.2": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hls-2.3": "hls-2.3",
+        "hpc-coveralls": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hydra": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "iserv-proxy": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "nixpkgs": [
+          "hs-nix-infra",
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2105": "nixpkgs-2105",
-        "nixpkgs-2111": "nixpkgs-2111",
-        "nixpkgs-2205": "nixpkgs-2205",
-        "nixpkgs-2211": "nixpkgs-2211",
+        "nixpkgs-2003": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2105": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2111": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2205": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2211": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2305": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "old-ghc-nix": "old-ghc-nix",
-        "stackage": "stackage",
-        "tullia": "tullia"
+        "old-ghc-nix": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "stackage": [
+          "hs-nix-infra",
+          "empty"
+        ]
       },
       "locked": {
-        "lastModified": 1675212661,
-        "narHash": "sha256-WgxnuJqjIyXG8qbIXD1WiuYrE7kVPhsa/+yPtLRPyjk=",
+        "lastModified": 1697195891,
+        "narHash": "sha256-0L803S/wcHmVebEwFxObYCYOaB14ZtBAFCdg0aRgH70=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "491800d10993761e50f1d9b1f0de02e73f13ad23",
+        "rev": "c6cb3ff56b001b211690da35f70827fab5bf3272",
         "type": "github"
       },
       "original": {
@@ -358,541 +215,94 @@
         "type": "github"
       }
     },
-    "hpc-coveralls": {
+    "hls-2.3": {
       "flake": false,
       "locked": {
-        "lastModified": 1607498076,
-        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
         "type": "github"
       },
       "original": {
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
         "type": "github"
       }
     },
-    "hydra": {
+    "hs-nix-infra": {
       "inputs": {
-        "nix": "nix",
-        "nixpkgs": [
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
+        "empty": "empty",
+        "hackage": "hackage",
+        "haskellNix": "haskellNix",
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1646878427,
-        "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "28b682b85b7efc5cf7974065792a1f22203a5927",
+        "lastModified": 1699020807,
+        "narHash": "sha256-T/vXF8PXGGnZXNAspFx3yhGFWh4n3a8f1UHlfuHWH1A=",
+        "owner": "kadena-io",
+        "repo": "hs-nix-infra",
+        "rev": "4e2cc022e56412eef42527f3876bae8c0ad0fe5d",
         "type": "github"
       },
       "original": {
-        "id": "hydra",
-        "type": "indirect"
-      }
-    },
-    "iserv-proxy": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1670983692,
-        "narHash": "sha256-avLo34JnI9HNyOuauK5R69usJm+GfW3MlyGlYxZhTgY=",
-        "ref": "hkm/remote-iserv",
-        "rev": "50d0abb3317ac439a4e7495b185a64af9b7b9300",
-        "revCount": 10,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
-      },
-      "original": {
-        "ref": "hkm/remote-iserv",
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
-      }
-    },
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
-    "mdbook-kroki-preprocessor": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1661755005,
-        "narHash": "sha256-1TJuUzfyMycWlOQH67LR63/ll2GDZz25I3JfScy/Jnw=",
-        "owner": "JoelCourtney",
-        "repo": "mdbook-kroki-preprocessor",
-        "rev": "93adb5716d035829efed27f65f2f0833a7d3e76f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "JoelCourtney",
-        "repo": "mdbook-kroki-preprocessor",
-        "type": "github"
-      }
-    },
-    "n2c": {
-      "inputs": {
-        "flake-utils": "flake-utils_5",
-        "nixpkgs": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1665039323,
-        "narHash": "sha256-SAh3ZjFGsaCI8FRzXQyp56qcGdAqgKEfJWPCQ0Sr7tQ=",
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "rev": "b008fe329ffb59b67bf9e7b08ede6ee792f2741a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "type": "github"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1643066034,
-        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "2.6.0",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix-nomad": {
-      "inputs": {
-        "flake-compat": "flake-compat_2",
-        "flake-utils": [
-          "haskellNix",
-          "tullia",
-          "nix2container",
-          "flake-utils"
-        ],
-        "gomod2nix": "gomod2nix",
-        "nixpkgs": [
-          "haskellNix",
-          "tullia",
-          "nixpkgs"
-        ],
-        "nixpkgs-lib": [
-          "haskellNix",
-          "tullia",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1658277770,
-        "narHash": "sha256-T/PgG3wUn8Z2rnzfxf2VqlR1CBjInPE0l1yVzXxPnt0=",
-        "owner": "tristanpemble",
-        "repo": "nix-nomad",
-        "rev": "054adcbdd0a836ae1c20951b67ed549131fd2d70",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tristanpemble",
-        "repo": "nix-nomad",
-        "type": "github"
-      }
-    },
-    "nix2container": {
-      "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1658567952,
-        "narHash": "sha256-XZ4ETYAMU7XcpEeAFP3NOl9yDXNuZAen/aIJ84G+VgA=",
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "rev": "60bb43d405991c1378baf15a40b5811a53e32ffa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "type": "github"
-      }
-    },
-    "nixago": {
-      "inputs": {
-        "flake-utils": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "flake-utils"
-        ],
-        "nixago-exts": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "blank"
-        ],
-        "nixpkgs": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1661824785,
-        "narHash": "sha256-/PnwdWoO/JugJZHtDUioQp3uRiWeXHUdgvoyNbXesz8=",
-        "owner": "nix-community",
-        "repo": "nixago",
-        "rev": "8c1f9e5f1578d4b2ea989f618588d62a335083c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixago",
+        "owner": "kadena-io",
+        "repo": "hs-nix-infra",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "lastModified": 1669833724,
+        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
         "repo": "nixpkgs",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
         "type": "github"
-      }
-    },
-    "nixpkgs-2105": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2205": {
-      "locked": {
-        "lastModified": 1663981975,
-        "narHash": "sha256-TKaxWAVJR+a5JJauKZqibmaM5e/Pi5tBDx9s8fl/kSE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "309faedb8338d3ae8ad8f1043b3ccf48c9cc2970",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211": {
-      "locked": {
-        "lastModified": 1669997163,
-        "narHash": "sha256-vhjC0kZMFoN6jzK0GR+tBzKi5KgBXgehadfidW8+Va4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "6f87491a54d8d64d30af6663cb3bf5d2ee7db958",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "indirect"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1663905476,
-        "narHash": "sha256-0CSwRKaYravh9v6qSlBpM0gNg0UhKT2lL7Yn6Zbx7UM=",
+        "lastModified": 1695318763,
+        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e14f9fb57315f0d4abde222364f19f88c77d2b79",
+        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1653581809,
-        "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "83658b28fe638a170a19b8933aa008b30640fbd1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1654807842,
-        "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fc909087cc3386955f21b4665731dbdaceefb1d8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1665087388,
-        "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "95fda953f6db2e9496d2682c4fc7b82f959878f7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "old-ghc-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1631092763,
-        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
-        "owner": "angerman",
-        "repo": "old-ghc-nix",
-        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "angerman",
-        "ref": "master",
-        "repo": "old-ghc-nix",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "haskellNix": "haskellNix",
-        "nixpkgs": [
-          "haskellNix",
-          "nixpkgs-unstable"
-        ]
+        "hs-nix-infra": "hs-nix-infra"
       }
     },
-    "stackage": {
-      "flake": false,
+    "systems": {
       "locked": {
-        "lastModified": 1675210232,
-        "narHash": "sha256-sRYTcYZYJ6s1AriIbndhPV/TtOr/LtMDGuSA1sn8Om0=",
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "rev": "eeb1f9bd9db2cbbcae9982d5e92c426f49db6328",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "type": "github"
-      }
-    },
-    "std": {
-      "inputs": {
-        "blank": "blank",
-        "devshell": "devshell",
-        "dmerge": "dmerge",
-        "flake-utils": "flake-utils_4",
-        "makes": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "blank"
-        ],
-        "mdbook-kroki-preprocessor": "mdbook-kroki-preprocessor",
-        "microvm": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "blank"
-        ],
-        "n2c": "n2c",
-        "nixago": "nixago",
-        "nixpkgs": "nixpkgs_4",
-        "yants": "yants"
-      },
-      "locked": {
-        "lastModified": 1665513321,
-        "narHash": "sha256-D6Pacw9yf/HMs84KYuCxHXnNDL7v43gtcka5URagFqE=",
-        "owner": "divnix",
-        "repo": "std",
-        "rev": "94a90eedb9cfc115b12ae8f6622d9904788559e4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "std",
-        "type": "github"
-      }
-    },
-    "tullia": {
-      "inputs": {
-        "nix-nomad": "nix-nomad",
-        "nix2container": "nix2container",
-        "nixpkgs": [
-          "haskellNix",
-          "nixpkgs"
-        ],
-        "std": "std"
-      },
-      "locked": {
-        "lastModified": 1668711738,
-        "narHash": "sha256-CBjky16o9pqsGE1bWu6nRlRajgSXMEk+yaFQLibqXcE=",
-        "owner": "input-output-hk",
-        "repo": "tullia",
-        "rev": "ead1f515c251f0e060060ef0e2356a51d3dfe4b0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "tullia",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "yants": {
-      "inputs": {
-        "nixpkgs": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1660507851,
-        "narHash": "sha256-BKjq7JnVuUR/xDtcv6Vm9GYGKAblisXrAgybor9hT/s=",
-        "owner": "divnix",
-        "repo": "yants",
-        "rev": "0b895ca02a8fa72bad50b454cb3e7d8a66407c96",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "yants",
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,7 @@
   description = "Data ingestion for Chainweb";
 
   inputs = {
-    nixpkgs.follows = "haskellNix/nixpkgs-unstable";
-    haskellNix.url = "github:input-output-hk/haskell.nix";
+    hs-nix-infra.url = "github:kadena-io/hs-nix-infra";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -16,11 +15,12 @@
     allow-import-from-derivation = "true";
   };
 
-  outputs = { self, nixpkgs, flake-utils, haskellNix }:
+  outputs = { self, hs-nix-infra, flake-utils }:
     flake-utils.lib.eachSystem
       [ "x86_64-linux" "x86_64-darwin"
         "aarch64-linux" "aarch64-darwin" ] (system:
         let
+          inherit (hs-nix-infra) nixpkgs haskellNix;
           pkgs = import nixpkgs {
             inherit system;
             inherit (haskellNix) config;

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Data ingestion for Chainweb";
 
   inputs = {
-    hs-nix-infra.url = "github:kadena-io/hs-nix-infra/enis/metadata-experiments";
+    hs-nix-infra.url = "github:kadena-io/hs-nix-infra";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -52,5 +52,9 @@
               echo works > $out
             '';
           };
+          devShell = flake.devShell;
+
+          # Expose the haskellNix project
+          project = defaultNix.project;
         });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
             echo ${name}: ${package}
             echo works > $out
           '';
-        in  flake // {
+        in {
           packages = {
             default = executable;
 

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,10 @@
         in  flake // {
           packages = {
             default = executable;
+
+            recursive = hs-nix-infra.lib.runRecursiveBuild system "chainweb-data" {}
+              "ln -s $(nix-build-flake ${self} packages.${system}.default) $out";
+
             chainweb-data-docker = defaultNix.dockerImage;
 
             # Built by CI

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Data ingestion for Chainweb";
 
   inputs = {
-    hs-nix-infra.url = "github:kadena-io/hs-nix-infra";
+    hs-nix-infra.url = "github:kadena-io/hs-nix-infra/enis/metadata-experiments";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -40,8 +40,8 @@
           packages = {
             default = executable;
 
-            recursive = hs-nix-infra.lib.runRecursiveBuild system "chainweb-data" {}
-              "ln -s $(nix-build-flake ${self} packages.${system}.default) $out";
+            recursive = with hs-nix-infra.lib.recursive system;
+              wrapRecursiveWithMeta "chainweb-data" "${wrapFlake self}.default";
 
             chainweb-data-docker = defaultNix.dockerImage;
 

--- a/flake.nix
+++ b/flake.nix
@@ -37,14 +37,16 @@
             echo works > $out
           '';
         in  flake // {
-          packages.default = executable;
-          packages.chainweb-data-docker = defaultNix.dockerImage;
+          packages = {
+            default = executable;
+            chainweb-data-docker = defaultNix.dockerImage;
 
-          # Built by CI
-          packages.check = pkgs.runCommand "check" {} ''
-            echo ${self.packages.${system}.default}
-            echo ${mkCheck "devShell" flake.devShell}
-            echo works > $out
-          '';
+            # Built by CI
+            check = pkgs.runCommand "check" {} ''
+              echo ${self.packages.${system}.default}
+              echo ${mkCheck "devShell" flake.devShell}
+              echo works > $out
+            '';
+          };
         });
 }


### PR DESCRIPTION
This PR does the following:

## Unify the GHC derivation used across Kadena projects

Instead of depending on `nixpkgs` and `haskellNix` directly, this flake now depends on our new `hs-nix-infra` flake and uses the `nixpkgs` and `haskellNix` revisions provided by it. The hash of the `nixpkgs` and `haskellNix` flakes used for defining the `haskell.nix` `project` determines the hash of the GHC package that gets used to compile the Haskell modules.  

When multiple projects depend on `nixpkgs` and `haskellNix` independently, it's very hard (and not really well supported by nix CLI) to make sure that they don't deviate from each others' `nixpkgs` and `haskellNix` pins arbitrarily. I.e. updating two projects' `flake.lock` files at slightly different times is likely to cause one of the pins to be on a different revision, even though the difference doesn't matter functionally.

These unnecessarily different GHC packages put a lot of pressure on our CI infrastructure, taking hours to build functionally equivalent GHC packages and bloating the cache (with binaries from all the architectures we build and cache for). That also bloats the `/nix/store` of any `chainweb-data` user that wants to `nix build` an uncached `chainweb-data` version.

### The new workflow for updating Haskell-Nix toolchain

After this PR, the new workflow for managing our Haskell dependencies used by Nix will involve the following steps:
* If an update to the toolchain is needed in order to fix the build, the first thing to try is to bump the `hs-nix-infra` dependency of this flake to the latest version. If that's not enough, we need to open a PR to `hs-nix-infra` to bump its proper input:
    * If we need to update our hackage pin so that we can build with newly released Haskell packages, we can just `nix flake lock --update-input hackage` and get a newer hackage snapshot without needing to introduce a new GHC derivation.
    * If we need to use a new GHC version provided by a newer `nixpkgs` version or if we need to bump our `haskellNix` pin for any reason we need to bump `nixpkgs` and `haskellNix`. The PR would preferably bump both of them to the latest version.

Hopefully, this new workflow will reduce the number of `nixpkgs` + `haskellNix` versions we depend on across our Haskell projects.

## Add a `recursive` alternative to the `default` package

As part of the CI automation for this repo, we're building and caching the Nix binaries for `chainweb-data`, which makes it convenient for any user to `nix build` chainweb-data from any commit/branch since all the dependencies will come from our binary cache. However, even without building anything locally, *evaluating* the `default` package of this flake takes a significant amount of time and involves downloading ~2 GB of Nix dependencies. This is due to the complexity of what `haskellNix` does for us at Nix evaluation time.

This PR introduces a `recursive` package to this flake's output, which uses `recursive-nix` to push the Nix evaluation of the `default` package into the build of a derivation. This means, any user that tries to `nix build .#recursive` will fetch the chainweb-data binary from our cache without having to perform any complex Nix evaluation locally or downloading the Nix dependencies of any such evaluation as long as the `recursive` derivation they're building is already in our binary cache. If not, the `recursive-nix` derivation will be built locally (in which case make sure your local Nix setup has `recursive-nix` enabled), which is essentially as much work as building `default` itself. This might still be worthwhile however, since subsequent builds of the same `recursive` derivation will complete immediately, without having to evaluate the `default` derivation again.
