### PR TITLE
Update the pact pin to latest master

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
-    tag: 43f25b540e0fbba37821ee7bb38db068146f7f04
-    --sha256: sha256-nh5+pJw7i8MAoYmahroyNiDk2sbXO96J+Aif9ov5jXc==
+    tag: e5c922664fb4df53e3b8e2c48618d71b3ef612ad
+    --sha256: sha256-t1p+Zd5I/mW2Aggi4xMRl0wj6k3ztsgzydvNkBachFA=
 
 source-repository-package
     type: git


### PR DESCRIPTION
This PR fixes a CI build failure caused by #172. That PR left the pact pin at a commit that was in a feature branch, which got merged and deleted. The fix is to pin the latest `master` of pact.