### PR TITLE
Remove hie.yaml

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,5 +1,0 @@
-cradle:
-  cabal:
-    - path: "haskell-src"
-      component: "lib:chainweb-data"
-


### PR DESCRIPTION
This PR removes the `hie.yaml` from the repository. Seems like the current `hie.yaml` doesn't take the `executable` stanza into account so it causes issues with HLS while working on the modules belonging to that stanza.

HLS works without any issues without the `hie.yaml` so seems like the default treatment works for the current project layout.