### PR TITLE
Fix events treatments for txs endpoint

### DIFF
--- a/haskell-src/exec/Chainweb/Server.hs
+++ b/haskell-src/exec/Chainweb/Server.hs
@@ -433,9 +433,10 @@ queryTxsByKey logger rk c =
         , Api._signer_capList = caps
         }
     let sigs = Api.Sig . unSignature . _signer_sig <$> dbSigners
+        sameBlock tx ev = (unBlockId $ _tx_block tx) == (unBlockId $ _ev_block ev)
 
     return $ (`fmap` r) $ \(tx,contHist, blk) ->
-      toApiTxDetail tx contHist blk evs signers sigs
+      toApiTxDetail tx contHist blk (filter (sameBlock tx) evs) signers sigs
 
 queryTxsByPactId :: LogFunctionIO Text -> Limit -> Text -> Connection -> IO [TxSummary]
 queryTxsByPactId logger limit pactid c =

--- a/haskell-src/exec/Chainweb/Server.hs
+++ b/haskell-src/exec/Chainweb/Server.hs
@@ -436,7 +436,8 @@ queryTxsByKey logger rk c =
         sameBlock tx ev = (unBlockId $ _tx_block tx) == (unBlockId $ _ev_block ev)
 
     return $ (`fmap` r) $ \(tx,contHist, blk) ->
-      toApiTxDetail tx contHist blk (filter (sameBlock tx) evs) signers sigs
+      let evsInTxBlock = filter (sameBlock tx) evs
+      in toApiTxDetail tx contHist blk evsInTxBlock signers sigs
 
 queryTxsByPactId :: LogFunctionIO Text -> Limit -> Text -> Connection -> IO [TxSummary]
 queryTxsByPactId logger limit pactid c =


### PR DESCRIPTION
In the presence of orphans, we can have multiple executions of the same transaction yielding different events every time. This PR makes sure that each execution gets associated with its own events only.