### PR TITLE
Add back an extended hie.yaml

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,13 @@
+cradle:
+  cabal:
+    - path: "haskell-src/lib"
+      component: "lib:chainweb-data"
+
+    - path: "haskell-src/exec"
+      component: "chainweb-data:exe:chainweb-data"
+
+    - path: "haskell-src/test"
+      component: "chainweb-data:test:testsuite"
+
+    - path: "haskell-src/bench"
+      component: "chainweb-data:bench:bench"


### PR DESCRIPTION
Seems like I made a mistake with https://github.com/kadena-io/chainweb-data/pull/175

Without the hie.yaml, HLS picks the right configuration for the modules in the haskell-src/exec folder, but it fails for others.

This PR adds back a hie.yaml that lists the folders for the individual stanzas from our chainweb-data.cabal