### PR TITLE
Bump v2.4.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.4.0 (2023-12-21)
+
+* Use CW-N's new block endpoint for history fill operations (#162)
+* Fix treatment of events associated to multiple transactions returned by the `txs/txs` endpoint (#177)
+* Update Haskell dependencies and GHC version (to 9.2.8) (#172, #174, #176)
+* Nix build setup improvements (#170)
+* Build with Nix and cache (to nixcache.chainweb.com) the project in GitHub actions (#165)
+* README improvements (#168, #169, 178)
+* Cabal build GitHub action fix (#166)
+* Fix the hie.yaml for HLS (Haskell LSP) (#175, #179)
+
 ## 2.3.0 (2023-08-14)
 
 * Fix `fill` and `backfill` issues caused by node's P2P API throttling, resulting in partial fills (#151)

--- a/haskell-src/chainweb-data.cabal
+++ b/haskell-src/chainweb-data.cabal
@@ -1,6 +1,6 @@
 cabal-version:   2.2
 name:            chainweb-data
-version:         2.3.0
+version:         2.4.0
 description:     Data ingestion for Chainweb.
 homepage:        https://github.com/kadena-io/chainweb-data
 author:          Colin Woodbury


### PR DESCRIPTION
This PR updates the `chainweb-data` package version to 2.4.0 and adds the change notes for the new release.