### PR TITLE
crossChainAccount derivation improvements for /txs/account

### DIFF
--- a/haskell-src/lib/ChainwebDb/Queries.hs
+++ b/haskell-src/lib/ChainwebDb/Queries.hs
@@ -316,19 +316,16 @@ joinXChainInfo tr = pgUnnest $ (customExpr_ $ \fromAcct toAcct idx mdName blk re
       " AND e.idx = " <> idx <> " - 1 " <>
       " AND " <> mdName <> " = 'coin' " <>
     " UNION ALL " <>
-    " SELECT e.params->>0 AS acct, e.chainid " <>
-    " FROM transactions tRec, transactions tSend, events e " <>
+    " SELECT e.params->2->>0 AS acct, CAST(e.params->>0 AS INT) AS chainid " <>
+    " FROM events e " <>
     " WHERE " <> mdName <> " = 'coin' " <>
       " AND " <> req <> " != 'cb' " <>
       " AND " <> fromAcct <> " = '' " <>
-      " AND tRec.block = " <> blk <>
-      " AND tRec.requestkey = " <> req <>
-      " AND tSend.requestkey = tRec.pactid " <>
-      " AND e.block = tSend.block " <>
-      " AND e.requestkey = tSend.requestkey " <>
-      " AND e.qualname = 'coin.TRANSFER_XCHAIN' " <>
-      " AND e.params->>1 = " <> toAcct <>
-      " AND e.params->>2 = CAST(" <> amt <> "AS VARCHAR) " <>
+      " AND e.block = " <> blk <>
+      " AND e.requestkey = " <> req <>
+      " AND e.qualname = 'pact.X_RESUME' " <>
+      " AND e.params->>1 = 'coin.transfer-crosschain' " <>
+      " AND e.params->2->>1 = " <> toAcct <>
     " UNION ALL " <>
     " SELECT NULL, NULL " <>
     " LIMIT 1 " <>

--- a/haskell-src/lib/ChainwebDb/Queries.hs
+++ b/haskell-src/lib/ChainwebDb/Queries.hs
@@ -312,7 +312,6 @@ joinXChainInfo tr = pgUnnest $ (customExpr_ $ \fromAcct toAcct idx mdName blk re
       " AND e.qualname = 'coin.TRANSFER_XCHAIN' " <>
       " AND e.params->>0 = " <> fromAcct <>
       " AND " <> toAcct <> " = '' " <>
-      " AND e.params->>2 = CAST(" <> amt <> "AS VARCHAR) " <>
       " AND e.idx = " <> idx <> " - 1 " <>
       " AND " <> mdName <> " = 'coin' " <>
     " UNION ALL " <>

--- a/haskell-src/lib/ChainwebDb/Queries.hs
+++ b/haskell-src/lib/ChainwebDb/Queries.hs
@@ -307,19 +307,19 @@ joinXChainInfo tr = pgUnnest $ (customExpr_ $ \fromAcct toAcct idx mdName blk re
   " LATERAL ( " <>
     " SELECT e.params->>1 AS acct, CAST(e.params->>3 AS INT) " <>
     " FROM events e " <>
-    " WHERE e.block = " <> blk <>
+    " WHERE " <> mdName <> " = 'coin' " <>
+      " AND " <> toAcct <> " = '' " <>
+      " AND e.block = " <> blk <>
       " AND e.requestkey = " <> req <>
+      " AND e.idx = " <> idx <> " - 1 " <>
       " AND e.qualname = 'coin.TRANSFER_XCHAIN' " <>
       " AND e.params->>0 = " <> fromAcct <>
-      " AND " <> toAcct <> " = '' " <>
-      " AND e.idx = " <> idx <> " - 1 " <>
-      " AND " <> mdName <> " = 'coin' " <>
     " UNION ALL " <>
     " SELECT e.params->2->>0 AS acct, CAST(e.params->>0 AS INT) AS chainid " <>
     " FROM events e " <>
     " WHERE " <> mdName <> " = 'coin' " <>
-      " AND " <> req <> " != 'cb' " <>
       " AND " <> fromAcct <> " = '' " <>
+      " AND " <> req <> " != 'cb' " <>
       " AND e.block = " <> blk <>
       " AND e.requestkey = " <> req <>
       " AND e.qualname = 'pact.X_RESUME' " <>


### PR DESCRIPTION
This PR improves the derivation of the `crossChainAccount` (and `crossChainId`) information for cross-chain transfers served by the `/txs/account` endpoint.:
* For the send side, it removes the parity check comparing the amount fields of the `TRANSFER` and the `TRANSFER_XCHAIN` events. The check is redundant and it's fragile due to the volatility of decimal representations.
* For the receive side, it switches to using the `X_RESUME` event on the receiving transaction as the data source, instead of the `TRANSFER_XCHAIN` event on the sending transaction. This has 2 benefits: It allows us to remove the amount check due to the same reasons, and it avoids relying on the data from an independent block being present.

Special thanks to @Takadenoshi for identifying this issue, helping me analyze it and suggesting the fix involving the `X_RESUME` event!