### PR TITLE
Allow multiple --extra-migrations-folder arguments

### DIFF
--- a/haskell-src/exec/Main.hs
+++ b/haskell-src/exec/Main.hs
@@ -151,8 +151,7 @@ runMigrations pool logg migAction migrations = do
   baseFiles <- case migrationsFolderBase migrations of
     Just migFolder -> getDir migFolder
     Nothing -> return baseMigrationFiles
-  extraFiles <- flip foldMap (migrationsFolderExtra migrations) $
-    \migFolder -> getDir migFolder
+  extraFiles <- foldMap getDir $ migrationsFolderExtra migrations
   let migrationFiles = baseFiles ++ extraFiles
 
   let steps = map (uncurry Mg.MigrationStep) migrationFiles

--- a/haskell-src/exec/Main.hs
+++ b/haskell-src/exec/Main.hs
@@ -151,9 +151,8 @@ runMigrations pool logg migAction migrations = do
   baseFiles <- case migrationsFolderBase migrations of
     Just migFolder -> getDir migFolder
     Nothing -> return baseMigrationFiles
-  extraFiles <- case migrationsFolderExtra migrations of
-    Just migFolder -> getDir migFolder
-    Nothing -> return []
+  extraFiles <- flip foldMap (migrationsFolderExtra migrations) $
+    \migFolder -> getDir migFolder
   let migrationFiles = baseFiles ++ extraFiles
 
   let steps = map (uncurry Mg.MigrationStep) migrationFiles

--- a/haskell-src/lib/ChainwebData/Env.hs
+++ b/haskell-src/lib/ChainwebData/Env.hs
@@ -71,7 +71,7 @@ type MigrationsFolder = FilePath
 
 data Migrations = Migrations
   { migrationsFolderBase :: Maybe MigrationsFolder
-  , migrationsFolderExtra :: Maybe MigrationsFolder
+  , migrationsFolderExtra :: [MigrationsFolder]
   } deriving (Show)
 
 data Args
@@ -278,7 +278,7 @@ migrationsParser = Migrations
        <> metavar "PATH"
        <> help "Path to the migrations folder"
       )
-  <*> optional (strOption
+  <*> many (strOption
         $ long "extra-migrations-folder"
        <> metavar "PATH"
        <> help "Path to extra migrations folder"


### PR DESCRIPTION
When provided with multiple `--extra-migrations-folder <PATH>` arguments, `chainweb-data` will gather the migration scripts from all those folders, extending the existing `--extra-migrations-folder` functionality.