### PR TITLE
Deduplicate migration steps that match exactly

### DIFF
--- a/haskell-src/exec/Main.hs
+++ b/haskell-src/exec/Main.hs
@@ -29,6 +29,8 @@ import           Control.Lens
 import           Control.Monad (forM_, void)
 import           Data.Bifunctor
 import qualified Data.ByteString as BS
+import           Data.Containers.ListUtils (nubOrd)
+
 import           Data.FileEmbed
 import qualified Data.Pool as P
 import           Data.String
@@ -154,7 +156,7 @@ runMigrations pool logg migAction migrations = do
   extraFiles <- foldMap getDir $ migrationsFolderExtra migrations
   let migrationFiles = baseFiles ++ extraFiles
 
-  let steps = map (uncurry Mg.MigrationStep) migrationFiles
+  let steps = nubOrd $ map (uncurry Mg.MigrationStep) migrationFiles
 
   Mg.runMigrations migAction steps pool logg
 

--- a/haskell-src/lib/ChainwebDb/Migration.hs
+++ b/haskell-src/lib/ChainwebDb/Migration.hs
@@ -26,7 +26,7 @@ type StepName = String
 data MigrationStep = MigrationStep
   { msName :: Mg.ScriptName
   , msBody :: BS.ByteString
-  }
+  } deriving (Eq, Ord)
 
 -- | Parse a ScriptName in the format "1.2.3_step_name" into a MigrationOrder
 -- and a StepName.


### PR DESCRIPTION
This will make it easier for downstream projects to manage their migrations. An example use case is a `@kadena/graph` developer/tester running the Kadena sandbox with a bundled `graph` service while mounting the `cwd-extra-migrations` folder of their local checkout.