### PR TITLE
Apply fast development rename

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -19,8 +19,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: 33022a1b4e8800d01120b5c2a41979adfe65d987
-    --sha256: 0wi52j109r2j8csqjanf4q9s2gyl3p16d9r58ljgyxjmp5ihjvi1
+    tag: 1b2de025cfdc09698bfb1ec3807cd85405d6a339
+    --sha256: sha256-06jvD1kmkmthcRkyWhVLTbytwabghInxqXQD/Lm7kbA=
 
 source-repository-package
   type: git

--- a/haskell-src/lib/ChainwebData/Types.hs
+++ b/haskell-src/lib/ChainwebData/Types.hs
@@ -122,6 +122,6 @@ withEventsMinHeight version errorMessage action = withVersion version onVersion 
     onVersion = \case
       "mainnet01" -> Just 1_722_500
       "testnet04" -> Just 1_261_000
-      "development" -> Just 14
-      "fast-development" -> Just 0
+      "recap-development" -> Just 14
+      "development" -> Just 0
       _ -> Nothing


### PR DESCRIPTION
This PR applies the recent `fast-development` -> `development` & `development` -> `recap-development` network rename that went into `chainweb`.