### PR TITLE
Add Verifiers to cw-data

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-api.git
-    tag: 1b2de025cfdc09698bfb1ec3807cd85405d6a339
-    --sha256: sha256-06jvD1kmkmthcRkyWhVLTbytwabghInxqXQD/Lm7kbA=
+    tag: b7eb7ffc3d6da99afe194205631a8f052308b7f4
+    --sha256: sha256-8Eamd+POoA8qEWJJZ2BPMDjlfVMvbBzOHXZP3QX8eEQ=
 
 source-repository-package
   type: git

--- a/haskell-src/exec/Chainweb/Lookups.hs
+++ b/haskell-src/exec/Chainweb/Lookups.hs
@@ -318,6 +318,7 @@ mkTransaction b (tx,txo) = Transaction
   , _tx_continuation = PgJSONB <$> _toutContinuation txo
   , _tx_txid = fromIntegral <$> _toutTxId txo
   , _tx_numEvents = Just $ fromIntegral $ length $ _toutEvents txo
+  , _tx_verifiers = PgJSONB <$> tx ^? to (CW._transaction_cmdStr) . key "verifiers"
   }
   where
     cmd = CW._transaction_cmd tx

--- a/haskell-src/exec/Chainweb/Server.hs
+++ b/haskell-src/exec/Chainweb/Server.hs
@@ -386,6 +386,7 @@ toApiTxDetail tx contHist blk evs signers sigs = TxDetail
         , _txDetail_previousSteps = V.toList (chSteps contHist) <$ chCode contHist
         , _txDetail_signers = signers
         , _txDetail_sigs = sigs
+        , _txDetail_verifiers =  unPgJsonb <$> _tx_verifiers tx
         }
   where
     unMaybeValue = maybe Null unPgJsonb

--- a/haskell-src/lib/ChainwebDb/Types/Transaction.hs
+++ b/haskell-src/lib/ChainwebDb/Types/Transaction.hs
@@ -54,6 +54,7 @@ data TransactionT f = Transaction
   , _tx_continuation :: C f (Maybe (PgJSONB Value))
   , _tx_txid :: C f (Maybe Int64)
   , _tx_numEvents :: C f (Maybe Int64)
+  , _tx_verifiers :: C f (Maybe (PgJSONB Value))
   }
   deriving stock (Generic)
   deriving anyclass (Beamable)


### PR DESCRIPTION
Now txHandler & txsHandler returns a TxDetail with list of verifiers (in json) to an api consumer.