### PR TITLE
Fix circulating supply calculation

### DIFF
--- a/haskell-src/exec/Chainweb/Coins.hs
+++ b/haskell-src/exec/Chainweb/Coins.hs
@@ -109,7 +109,7 @@ decodeAllocations
   :: ByteString
   -> Vector AllocationEntry
 decodeAllocations bs =
-  case CSV.decode CSV.HasHeader (BL.fromStrict bs) of
+  case CSV.decode CSV.NoHeader (BL.fromStrict bs) of
     Left e -> error
       $ "cannot construct genesis allocations: "
       <> show e


### PR DESCRIPTION
decodeAllocations assumes that token_payments.csv has a header row but actually the first row is a 10M token allocation, which therefore is missed in the circulating supply calculation.

Change-Id: Id0000000fedef0d50b1e62c003c4d4056d0ea603